### PR TITLE
Add infection struct input to replace manual parameter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.0.6] - 2026-03-16
 
 ### Changed (Breaking)
 - **`daedalus()` function signature refactored**: second positional argument now takes infection parameters (`infection`) instead of scalar/vector `r0`. Users must pass parameters via `InfectionData` object rather than individual keyword arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (Breaking)
+- **`daedalus()` function signature refactored**: second positional argument now takes infection parameters (`infection`) instead of scalar/vector `r0`. Users must pass parameters via `InfectionData` object rather than individual keyword arguments
+  - **Old interface**: `daedalus(country, r0::Float64; sigma=..., epsilon=..., eta=..., ...)`
+  - **New interface**: `daedalus(country, infection; npi=..., log_rt=..., time_end=..., increment=..., n_threads=...)`
+- Removed all infection-parameter keyword arguments: `sigma`, `p_sigma`, `epsilon`, `rho`, `eta`, `omega`, `gamma_Ia`, `gamma_Is`, `gamma_H`, `nu`
+  - All epidemiological parameters now encapsulated in `InfectionData` object
+  - Users customize parameters by fetching `InfectionData` and modifying fields before calling `daedalus()`
+
+### Added
+- New dispatch methods for `daedalus()`:
+  1. String pathogen name: `daedalus(country, "sars-cov-2 delta"; ...)`
+  2. Single `InfectionData`: `daedalus(country, infection_obj; ...)`
+  3. Vector `InfectionData`: `daedalus(country, [inf1, inf2, ...]; ...)`
+- `extract_infection_params()` helper function to extract and expand epidemiological parameters from `InfectionData`
+- `InfectionData` is mutable, allowing users to customize parameters post-fetch: `inf = get_pathogen("sars-cov-2 delta"); inf.r0 = 2.5`
+- **Infection names are normalized to lowercase**: all pathogen names are stored and looked up as lowercase strings (e.g., `"sars-cov-2 delta"`, `"influenza 2009"`)
+
+### Migration Guide
+```julia
+# Old (no longer works):
+result = daedalus("Australia", 2.5, sigma=0.217, epsilon=0.58, time_end=200.0)
+
+# New (string pathogen, lowercase names):
+result = daedalus("Australia", "sars-cov-2 delta", time_end=200.0)
+
+# New (custom infection):
+infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection.r0 = 2.5
+result = daedalus("Australia", infection, time_end=200.0)
+
+# New (vector of infections):
+infections = [
+    Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+    Daedalus.DataLoader.get_pathogen("influenza 2009")
+]
+results = daedalus("Australia", infections, time_end=200.0)
+```
+
 ## [0.0.5] - 2026-03-09
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Daedalus"
 uuid = "05fc9732-d2bf-478b-9a56-f88318f7a02f"
 authors = ["Pratik Gupte <pratikgupte16@gmail.com> and contributors"]
-version = "0.0.5"
+version = "0.0.6"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Pkg.add(url="git@github.com:pratikunterwegs/Daedalus.jl.git")
 ```julia
 using Daedalus
 
-daedalus("Australia", 5.0, time_end=600.0)
+result = daedalus("Australia", "sars-cov-2 delta", time_end=600.0)
 ```
 
 ## Related projects

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -543,10 +543,10 @@ uuid = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
 version = "0.4.5"
 
 [[deps.FFMPEG_jll]]
-deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "PCRE2_jll", "Zlib_jll", "libaom_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
-git-tree-sha1 = "01ba9d15e9eae375dc1eb9589df76b3572acd3f2"
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "PCRE2_jll", "Zlib_jll", "libaom_jll", "libass_jll", "libfdk_aac_jll", "libva_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
+git-tree-sha1 = "66381d7059b5f3f6162f28831854008040a4e905"
 uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
-version = "8.0.1+0"
+version = "8.0.1+1"
 
 [[deps.FastBroadcast]]
 deps = ["ArrayInterface", "LinearAlgebra", "Polyester", "Static", "StaticArrayInterface", "StrideArraysCore"]
@@ -795,9 +795,9 @@ version = "1.0.2"
 
 [[deps.HTTP]]
 deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "PrecompileTools", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
-git-tree-sha1 = "5e6fe50ae7f23d171f44e311c2960294aaa0beb5"
+git-tree-sha1 = "51059d23c8bb67911a2e6fd5130229113735fc7e"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "1.10.19"
+version = "1.11.0"
 
 [[deps.HarfBuzz_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll"]
@@ -1069,9 +1069,9 @@ version = "1.11.0"
 
 [[deps.LinearSolve]]
 deps = ["ArrayInterface", "ChainRulesCore", "ConcreteStructs", "DocStringExtensions", "EnumX", "GPUArraysCore", "InteractiveUtils", "Krylov", "Libdl", "LinearAlgebra", "MKL_jll", "Markdown", "OpenBLAS_jll", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLLogging", "SciMLOperators", "Setfield", "StaticArraysCore"]
-git-tree-sha1 = "ba64436736405d666e0d22d54ee0e1b04e2e2b02"
+git-tree-sha1 = "57a7bea58da7de6906f2621294ea35656cb40c5f"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "3.64.0"
+version = "3.66.0"
 
     [deps.LinearSolve.extensions]
     LinearSolveAMDGPUExt = "AMDGPU"
@@ -1412,9 +1412,9 @@ version = "1.22.0"
 
 [[deps.OrdinaryDiffEqCore]]
 deps = ["ADTypes", "Accessors", "Adapt", "ArrayInterface", "ConcreteStructs", "DataStructures", "DiffEqBase", "DocStringExtensions", "EnumX", "EnzymeCore", "FastBroadcast", "FastClosures", "FastPower", "FillArrays", "FunctionWrappersWrappers", "InteractiveUtils", "LinearAlgebra", "Logging", "MacroTools", "MuladdMacro", "Polyester", "PrecompileTools", "Preferences", "Random", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLLogging", "SciMLOperators", "SciMLStructures", "Static", "StaticArrayInterface", "StaticArraysCore", "SymbolicIndexingInterface", "TruncatedStacktraces"]
-git-tree-sha1 = "e051c1fb69b1cb1511a00161b97e7a79e0b70687"
+git-tree-sha1 = "b0b386226690c23ebc771cd68a37d08c55b60924"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
-version = "3.17.0"
+version = "3.21.0"
 
     [deps.OrdinaryDiffEqCore.extensions]
     OrdinaryDiffEqCoreMooncakeExt = "Mooncake"
@@ -1852,9 +1852,9 @@ version = "0.1.0"
 
 [[deps.SciMLBase]]
 deps = ["ADTypes", "Accessors", "Adapt", "ArrayInterface", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "EnumX", "FunctionWrappersWrappers", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "Moshi", "PreallocationTools", "PrecompileTools", "Preferences", "Printf", "RecipesBase", "RecursiveArrayTools", "Reexport", "RuntimeGeneratedFunctions", "SciMLLogging", "SciMLOperators", "SciMLPublic", "SciMLStructures", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface"]
-git-tree-sha1 = "4675d321bfebe190d22dc4d9de6af7e318d5174a"
+git-tree-sha1 = "8787e28326c99b0c9c706b51da525ad09d03c56f"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "2.148.0"
+version = "2.149.0"
 
     [deps.SciMLBase.extensions]
     SciMLBaseChainRulesCoreExt = "ChainRulesCore"
@@ -2056,9 +2056,9 @@ version = "1.9.0"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
-git-tree-sha1 = "0f529006004a8be48f1be25f3451186579392d47"
+git-tree-sha1 = "246a8bb2e6667f832eea063c3a56aef96429a3db"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.17"
+version = "1.9.18"
 weakdeps = ["ChainRulesCore", "Statistics"]
 
     [deps.StaticArrays.extensions]
@@ -2323,6 +2323,12 @@ git-tree-sha1 = "7ed9347888fac59a618302ee38216dd0379c480d"
 uuid = "ea2f1a96-1ddc-540d-b46f-429655e07cfa"
 version = "0.9.12+0"
 
+[[deps.Xorg_libpciaccess_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "4909eb8f1cbf6bd4b1c30dd18b2ead9019ef2fad"
+uuid = "a65dc6b1-eb27-53a1-bb3e-dea574b5389e"
+version = "0.18.1+0"
+
 [[deps.Xorg_libxcb_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXau_jll", "Xorg_libXdmcp_jll"]
 git-tree-sha1 = "bfcaf7ec088eaba362093393fe11aa141fa15422"
@@ -2435,6 +2441,12 @@ git-tree-sha1 = "9bf7903af251d2050b467f76bdbe57ce541f7f4f"
 uuid = "1183f4f0-6f2a-5f1a-908b-139f9cdfea6f"
 version = "0.2.2+0"
 
+[[deps.libdrm_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libpciaccess_jll"]
+git-tree-sha1 = "63aac0bcb0b582e11bad965cef4a689905456c03"
+uuid = "8e53e030-5e6c-5a89-a30b-be5b7263a166"
+version = "2.4.125+1"
+
 [[deps.libevdev_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
 git-tree-sha1 = "56d643b57b188d30cccc25e331d416d3d358e557"
@@ -2458,6 +2470,12 @@ deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
 git-tree-sha1 = "e015f211ebb898c8180887012b938f3851e719ac"
 uuid = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
 version = "1.6.55+0"
+
+[[deps.libva_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll", "Xorg_libXext_jll", "Xorg_libXfixes_jll", "libdrm_jll"]
+git-tree-sha1 = "7dbf96baae3310fe2fa0df0ccbb3c6288d5816c9"
+uuid = "9a156e7d-b971-5f62-b2c9-67348b8fb97c"
+version = "2.23.0+0"
 
 [[deps.libvorbis_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Ogg_jll"]

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -13,7 +13,9 @@ This section shows various benchmarks.
 using Daedalus
 using BenchmarkTools
 
-@benchmark daedalus("Australia", 2.5, time_end=600.0)
+infection_01 = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection_01.r0 = 2.5
+@benchmark daedalus("Australia", infection_01, time_end=600.0)
 ```
 
 ```@example benchmarking_02
@@ -21,7 +23,9 @@ using BenchmarkTools
 using Daedalus
 using BenchmarkTools
 
-@benchmark daedalus("Australia", 2.5, time_end=100.0)
+infection_02 = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection_02.r0 = 2.5
+@benchmark daedalus("Australia", infection_02, time_end=100.0)
 ```
 
 ## Effect of logging $R_t$
@@ -33,7 +37,9 @@ using Daedalus
 using BenchmarkTools
 
 # turn off Rt logging and compare with benchmark above
-@benchmark daedalus("Australia", 2.5, log_rt=false, time_end=600.0)
+infection_rt = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection_rt.r0 = 2.5
+@benchmark daedalus("Australia", infection_rt, log_rt=false, time_end=600.0)
 ```
 
 ## Reactive events
@@ -47,12 +53,16 @@ using BenchmarkTools
 
 npi = Daedalus.DaedalusStructs.Npi(20000.0, (coef=0.7,));
 
-@benchmark daedalus("Australia", 5.0, npi=npi, time_end=600.0)
+infection_re = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection_re.r0 = 5.0
+@benchmark daedalus("Australia", infection_re, npi=npi, time_end=600.0)
 ```
 
 ```@example benchmarking_reactive_event
 # shorter duration
-@benchmark daedalus("Australia", 5.0, npi=npi, time_end=100.0)
+infection_re2 = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection_re2.r0 = 5.0
+@benchmark daedalus("Australia", infection_re2, npi=npi, time_end=100.0)
 ```
 
 ## Timed events
@@ -69,11 +79,15 @@ timed_npi = Daedalus.DaedalusStructs.TimedNpi(
     "three_phase_lockdown"
 )
 
-@benchmark daedalus("Australia", 3.0, npi=timed_npi, time_end=600.0)
+infection_te = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection_te.r0 = 3.0
+@benchmark daedalus("Australia", infection_te, npi=timed_npi, time_end=600.0)
 ```
 
 Timed events do not need $R_t$ logging and can be benchmarked without it.
 
 ```@example benchmarking_timed_event
-@benchmark daedalus("Australia", 3.0, npi=timed_npi, time_end=600.0, log_rt=false)
+infection_te2 = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection_te2.r0 = 3.0
+@benchmark daedalus("Australia", infection_te2, npi=timed_npi, time_end=600.0, log_rt=false)
 ```

--- a/docs/src/country_data.md
+++ b/docs/src/country_data.md
@@ -59,28 +59,30 @@ uk.contact_matrix
 ```@example pathogen_struct
 using Daedalus
 
-delta = Daedalus.DataLoader.get_pathogen("SARS-CoV-2 delta")
+delta = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
 
 delta
 ```
 
 ## Preparing country inputs for the model
 
-Pass a country name string directly to [`daedalus`](@ref) to run the model with country-specific demography, contacts, and workforce data:
+Pass a country name string and a pathogen name to [`daedalus`](@ref) to run the model with country-specific demography, contacts, and workforce data:
 
 ```@example country_inputs
 using Daedalus
 
-result = daedalus("United Kingdom", 2.5, time_end=600.0)
+result = daedalus("United Kingdom", "sars-cov-2 delta", time_end=600.0)
 ```
 
-You can also pass a [`DataLoader.CountryData`](@ref) struct directly.
-This is useful when you want to pre-fetch or modify country data before running the model:
+You can also pass a [`DataLoader.CountryData`](@ref) struct directly and customize infection parameters.
+This is useful when you want to pre-fetch or modify country or infection data before running the model:
 
 ```@example country_inputs
 # Pre-fetch country data and pass the struct directly
 uk = Daedalus.DataLoader.get_country("United Kingdom")
-result2 = daedalus(uk, 2.5, time_end=600.0)
+infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection.r0 = 2.5
+result2 = daedalus(uk, infection, time_end=600.0)
 ```
 
 The `Data` sub-module also exposes lower-level functions for inspecting or manipulating the country arrays directly.

--- a/docs/src/ensemble.md
+++ b/docs/src/ensemble.md
@@ -11,15 +11,22 @@ Better functionality for working with ensemble outputs, using the inbuilt DE.jl 
 
 ## Basic ensemble run
 
-Pass a `Vector{Float64}` as the `r0` argument instead of a scalar value:
+Pass a `Vector{InfectionData}` with different R0 values:
 
 ```@example ensemble_basic
 using Daedalus
 using Plots
 
 # Run model with three different R0 values
-r0_values = [1.5, 2.5, 3.5]
-results = daedalus("Australia", r0_values, time_end=600.0);
+infections = [
+    Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+    Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+    Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+]
+infections[1].r0 = 1.5
+infections[2].r0 = 2.5
+infections[3].r0 = 3.5
+results = daedalus("Australia", infections, time_end=600.0);
 
 # Each result contains: sol, saves, npi, r0
 println("Number of results: ", length(results))
@@ -97,7 +104,11 @@ npi = Daedalus.DaedalusStructs.Npi(10000.0, (coef=0.5,))
 
 # Run ensemble with same NPI applied to all R0 values
 r0_range = [1.5, 2.0, 2.5, 3.0, 3.5]
-results_with_npi = daedalus("Australia", r0_range, npi=npi, time_end=600.0)
+infections_npi = [Daedalus.DataLoader.get_pathogen("sars-cov-2 delta") for _ in r0_range]
+for (i, r0) in enumerate(r0_range)
+    infections_npi[i].r0 = r0
+end
+results_with_npi = daedalus("Australia", infections_npi, npi=npi, time_end=600.0)
 ```
 
 ## Large-scale parameter sweeps
@@ -107,7 +118,11 @@ For broader sensitivity analyses, you can define finer-grained R0 ranges:
 ```@example ensemble_basic
 # Fine-grained sweep from 1.0 to 5.0 in 0.5 increments
 r0_sweep = collect(1.0:0.5:5.0)
-results_sweep = daedalus("Australia", r0_sweep, time_end=300.0);
+infections_sweep = [Daedalus.DataLoader.get_pathogen("sars-cov-2 delta") for _ in r0_sweep]
+for (i, r0) in enumerate(r0_sweep)
+    infections_sweep[i].r0 = r0
+end
+results_sweep = daedalus("Australia", infections_sweep, time_end=300.0);
 
 # NOTE: add plot of infectious or exposed
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,7 +34,9 @@ using Daedalus
 using Plots
 
 # pump up r0 to get peak within 50 days
-data = daedalus("Canada", 5.0, time_end=600.0);
+infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection.r0 = 5.0
+data = daedalus("Canada", infection, time_end=600.0);
 
 # plot exposed group
 times = Daedalus.Outputs.get_times(data)
@@ -66,7 +68,9 @@ using Daedalus
 using Plots
 
 # Run the model using UK demography and contact patterns
-data_uk = daedalus("United Kingdom", 2.5, time_end=600.0)
+infection_uk = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection_uk.r0 = 2.5
+data_uk = daedalus("United Kingdom", infection_uk, time_end=600.0)
 
 times_uk = Daedalus.Outputs.get_times(data_uk)
 exposed_uk = Daedalus.Outputs.get_values(data_uk, "E", 1)

--- a/docs/src/npis.md
+++ b/docs/src/npis.md
@@ -16,8 +16,14 @@ using Plots
 hosp_threshold=20000.0
 a = Daedalus.DaedalusStructs.Npi(hosp_threshold, (coef=0.7,));
 
-data = daedalus("Australia", 3.0, npi=a, time_end=600.0);
-data_default = daedalus("Australia", 3.0, time_end=600.0);
+# Create infection data for both runs
+infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection.r0 = 3.0
+infection_default = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection_default.r0 = 3.0
+
+data = daedalus("Australia", infection, npi=a, time_end=600.0);
+data_default = daedalus("Australia", infection_default, time_end=600.0);
 
 # plot new hosp over time
 iHosp = Daedalus.Constants.get_indices("H")
@@ -61,7 +67,11 @@ timed_npi = Daedalus.DaedalusStructs.TimedNpi(
     "three_phase_lockdown"
 )
 
-data = daedalus("Australia", 3.0, npi=timed_npi, time_end=600.0);
+# Create infection data
+infection_timed = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection_timed.r0 = 3.0
+
+data = daedalus("Australia", infection_timed, npi=timed_npi, time_end=600.0);
 
 # get exposed
 iExpo = Daedalus.Constants.get_indices("E")

--- a/docs/src/settings.md
+++ b/docs/src/settings.md
@@ -36,10 +36,12 @@ Daedalus.Data.get_settings(cd_multi) # vector of two → 2
 
 ## Running the model with multiple settings
 
-Pass the modified struct directly to [`daedalus`](@ref):
+Pass the modified struct directly to [`daedalus`](@ref) along with infection parameters:
 
 ```@example multi_settings
-result_multi = daedalus(cd_multi, 2.5, time_end = 300.0)
+infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection.r0 = 2.5
+result_multi = daedalus(cd_multi, infection, time_end = 300.0)
 
 times  = Daedalus.Outputs.get_times(result_multi)
 deaths = Daedalus.Outputs.get_values(result_multi, "D", 1)
@@ -65,8 +67,13 @@ Adding a second identical matrix doubles the total contacts, which halves `β`, 
 cd_double = deepcopy(cd)
 cd_double.contact_matrix = [cm, cm]  # two equal settings
 
-result_single = daedalus(cd, 2.5, time_end = 300.0, log_rt = false)
-result_double = daedalus(cd_double, 2.5, time_end = 300.0, log_rt = false)
+infection_single = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection_single.r0 = 2.5
+infection_double = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection_double.r0 = 2.5
+
+result_single = daedalus(cd, infection_single, time_end = 300.0, log_rt = false)
+result_double = daedalus(cd_double, infection_double, time_end = 300.0, log_rt = false)
 
 d_single = last(Daedalus.Outputs.get_values(result_single, "D", 1))
 d_double = last(Daedalus.Outputs.get_values(result_double, "D", 1))

--- a/src/DataLoader.jl
+++ b/src/DataLoader.jl
@@ -193,7 +193,7 @@ function _load_pathogens()
         # hfr[age] = IFR[age] / IHR[age]  (clamp to avoid div-by-zero)
         hfr = ifr_4 ./ max.(ihr_4, 1e-12)
 
-        result[pname] = InfectionData(
+        result[lowercase(pname)] = InfectionData(
             r0, sigma, ps, epsilon,
             gamma_Is, gamma_Ia, gamma_H_rec, gamma_H_death, rho,
             eta, hfr, ifr_4
@@ -214,8 +214,9 @@ function get_pathogen(name::String)::InfectionData
         _pathogen_cache[] = _load_pathogens()
     end
     d = _pathogen_cache[]
-    haskey(d, name) || error("Pathogen not found: $name. Available: " * join(keys(d), ", "))
-    return d[name]
+    name_lower = lowercase(name)
+    haskey(d, name_lower) || error("Pathogen not found: $name. Available: " * join(keys(d), ", "))
+    return d[name_lower]
 end
 
 """

--- a/src/DataLoader.jl
+++ b/src/DataLoader.jl
@@ -215,7 +215,8 @@ function get_pathogen(name::String)::InfectionData
     end
     d = _pathogen_cache[]
     name_lower = lowercase(name)
-    haskey(d, name_lower) || error("Pathogen not found: $name. Available: " * join(keys(d), ", "))
+    haskey(d, name_lower) ||
+        error("Pathogen not found: $name. Available: " * join(keys(d), ", "))
     return d[name_lower]
 end
 

--- a/src/Ensemble.jl
+++ b/src/Ensemble.jl
@@ -26,7 +26,8 @@ A `Vector{NamedTuple}` where each element contains:
 - `npi`: The NPI specification used
 - `r0`: The R0 value for this infection
 """
-function daedalus(country::Union{String, DataLoader.CountryData}, infections::Vector{DataLoader.InfectionData};
+function daedalus(country::Union{String, DataLoader.CountryData},
+        infections::Vector{DataLoader.InfectionData};
         npi::Union{Npi, TimedNpi, Nothing} = nothing,
         log_rt::Bool = true,
         time_end::Float64 = 100.0,
@@ -112,7 +113,8 @@ function daedalus(country::Union{String, DataLoader.CountryData}, infections::Ve
     end
 
     # Solve ensemble
-    ensemble_solution = daedalus_internal(length(r0_values), shared_data, param_sets, cb_set)
+    ensemble_solution = daedalus_internal(
+        length(r0_values), shared_data, param_sets, cb_set)
 
     # Format results: Vector of NamedTuples, one per r0
     results = []
@@ -125,7 +127,8 @@ function daedalus(country::Union{String, DataLoader.CountryData}, infections::Ve
             nothing
         end
 
-        push!(results, (sol = ensemble_solution[i], saves = saved_vals, npi = npi, r0 = r0_values[i]))
+        push!(results, (
+            sol = ensemble_solution[i], saves = saved_vals, npi = npi, r0 = r0_values[i]))
     end
 
     return results

--- a/src/Ensemble.jl
+++ b/src/Ensemble.jl
@@ -1,102 +1,98 @@
-# Vector R0 dispatch for daedalus function
-# This file extends the daedalus function from Model.jl to handle Vector{Float64} r0 input
+# Vector InfectionData dispatch for daedalus function
+# This file extends the daedalus function from Model.jl to handle Vector{InfectionData} input
 
 """
-    daedalus(; country, r0::Vector{Float64}, ...)
+    daedalus(country, infections::Vector{InfectionData}; npi, log_rt, time_end, increment, n_threads)
 
-Run the daedalus epidemic model with multiple R0 values in parallel.
+Run the daedalus epidemic model with multiple infection parameters in parallel.
 
-This is the vector-R0 dispatch of the `daedalus` function. It orchestrates
-multi-run ODE solving across multiple R0 values using shared computation
-and optional multi-threading.
+This is the vector-InfectionData dispatch of the `daedalus` function. It orchestrates
+multi-run ODE solving across multiple InfectionData objects (extracting R0 values)
+using shared computation and optional multi-threading.
 
 # Arguments
 - `country`: Country to model (String or CountryData struct)
-- `r0::Vector{Float64}`: Vector of reproduction numbers to simulate
-- Other arguments: Same as scalar daedalus() function
+- `infections::Vector{InfectionData}`: Vector of infection parameter objects
+- `npi`: Non-pharmaceutical intervention (optional)
+- `log_rt`: Whether to log effective reproduction number (default: true)
+- `time_end`: Final simulation time in days (default: 100.0)
+- `increment`: Savepoint interval in days (default: 1.0)
+- `n_threads`: Number of threads for parallel execution (default: 1)
 
 # Returns
 A `Vector{NamedTuple}` where each element contains:
-- `sol`: The ODE solution for that R0 value
+- `sol`: The ODE solution for that infection
 - `saves`: Saved event values (if applicable)
 - `npi`: The NPI specification used
-- `r0`: The R0 value for this run
+- `r0`: The R0 value for this infection
 """
-function daedalus(country::Union{String, DataLoader.CountryData},
-        r0::Vector{Float64};
-        sigma = 0.217,
-        p_sigma = 0.867,
-        epsilon = 0.58,
-        rho = 0.003,
-        eta::Vector{Float64} = [0.018, 0.082, 0.018, 0.246],
-        omega::Vector{Float64} = [0.012, 0.012, 0.012, 0.012],
-        gamma_Ia = 0.476,
-        gamma_Is = 0.25,
-        gamma_H::Vector{Float64} = [0.034, 0.034, 0.034, 0.034],
-        nu = 0.0,
-        psi::Float64 = 1.0 / 270.0,
+function daedalus(country::Union{String, DataLoader.CountryData}, infections::Vector{DataLoader.InfectionData};
         npi::Union{Npi, TimedNpi, Nothing} = nothing,
-        log_rt = true,
+        log_rt::Bool = true,
         time_end::Float64 = 100.0,
-        increment::Float64 = 1.0)
+        increment::Float64 = 1.0,
+        n_threads::Int = 1)
 
-    # resolve country string to CountryData if needed
+    # Extract R0 values from infection list
+    r0_values = [inf.r0 for inf in infections]
+
+    # Use first infection's other parameters
+    inf_params = extract_infection_params(infections[1])
+
+    # Resolve country string to CountryData if needed
     cd = isa(country, String) ? DataLoader.get_country(country) : country
 
-    n_runs = length(r0)
-
-    # Prepare shared data (done once for all runs)
+    # Prepare shared data once
     shared_data = prepare_shared_data(cd, time_end, increment)
 
-    # prepare betas and NGMs for each R0 value
-    beta = get_beta(
-        shared_data.contacts_unscaled, r0, sigma, p_sigma,
-        epsilon, gamma_Ia, gamma_Is
-    )
+    # Get country data for beta calculation
+    contacts_unscaled = total_contacts(prepare_contacts(cd; scaled = false))
+    cw = worker_contacts(cd)
+    demog = prepare_demog(cd)
+    size::Int = N_TOTAL_GROUPS * N_COMPARTMENTS * N_VACCINE_STRATA
+    psi::Float64 = 1.0 / 270.0
 
-    ngm = get_ngm(
-        shared_data.contacts_unscaled, beta, sigma, p_sigma,
-        epsilon, gamma_Ia, gamma_Is
-    )
+    # Create parameter sets - one per r0 value
+    contacts_array = contacts3d(cd)
+    settings = get_settings(cd)
+    param_sets = []
 
-    # Ensure beta and ngm are vectors
-    if isa(beta, Float64)
-        beta = [beta]
+    for r0 in r0_values
+        beta = get_beta(
+            contacts_unscaled,
+            r0, inf_params.sigma, inf_params.p_sigma,
+            inf_params.epsilon, inf_params.gamma_Ia, inf_params.gamma_Is
+        )
+
+        ngm = get_ngm(
+            contacts_unscaled,
+            beta, inf_params.sigma, inf_params.p_sigma,
+            inf_params.epsilon, inf_params.gamma_Ia, inf_params.gamma_Is
+        )
+
+        cm_temp::Matrix{Float64} = ones(N_TOTAL_GROUPS, N_TOTAL_GROUPS)
+        params = Params(
+            contacts_array, cm_temp, settings, ngm, demog,
+            cw, beta, beta, inf_params.sigma, inf_params.p_sigma,
+            inf_params.epsilon, inf_params.rho, inf_params.eta, inf_params.omega,
+            inf_params.omega, inf_params.gamma_Ia, inf_params.gamma_Is,
+            inf_params.gamma_H, inf_params.nu, psi, size
+        )
+        push!(param_sets, params)
     end
-    if !isa(ngm, Vector)
-        ngm = [ngm]
-    end
 
-    # Expand age-varying parameters
-    eta_exp = [eta; repeat([eta[i_WORKING_AGE]], N_ECON_GROUPS)]
-    omega_exp = [omega; repeat([omega[i_WORKING_AGE]], N_ECON_GROUPS)]
-    gamma_H_exp = [gamma_H; repeat([gamma_H[i_WORKING_AGE]], N_ECON_GROUPS)]
-
-    size_state::Int = N_TOTAL_GROUPS * N_COMPARTMENTS * N_VACCINE_STRATA
-
-    # Create parameter sets for each R0 value
-    param_sets = [Params(
-                      shared_data.contacts_array, shared_data.cm_temp,
-                      shared_data.settings,
-                      ngm[i], shared_data.demog,
-                      shared_data.cw, beta[i], beta[i],
-                      sigma, p_sigma, epsilon, rho, eta_exp,
-                      omega_exp, omega_exp, gamma_Ia, gamma_Is,
-                      gamma_H_exp, nu, psi, size_state
-                  ) for i in 1:n_runs]
-
-    # Build callback set (shared across all runs)
+    # Build callback set
+    savepoints = shared_data.savepoints
     if isnothing(npi)
+        cb_set = CallbackSet()
         if log_rt
-            rt_logger = make_rt_logger(shared_data.savepoints)
+            rt_logger = make_rt_logger(savepoints)
             cb_set = CallbackSet(rt_logger)
-        else
-            cb_set = CallbackSet()
         end
     elseif isa(npi, TimedNpi)
         timed_callbacks = make_timed_npi_callbacks(npi)
         if log_rt
-            rt_logger = make_rt_logger(shared_data.savepoints)
+            rt_logger = make_rt_logger(savepoints)
             cb_set = CallbackSet(timed_callbacks, rt_logger)
         else
             cb_set = timed_callbacks
@@ -105,37 +101,32 @@ function daedalus(country::Union{String, DataLoader.CountryData},
         coef = get_coef(npi)
         fn_effect_on = make_param_changer("beta", .*, coef)
         fn_effect_off = make_param_reset("beta")
-        save_events = make_save_events(npi, shared_data.savepoints)
-        events = make_events(npi, fn_effect_on, fn_effect_off, shared_data.savepoints)
+        save_events = make_save_events(npi, savepoints)
+        events = make_events(npi, fn_effect_on, fn_effect_off, savepoints)
         if log_rt
-            rt_logger = make_rt_logger(shared_data.savepoints)
+            rt_logger = make_rt_logger(savepoints)
             cb_set = CallbackSet(events, save_events, rt_logger)
         else
             cb_set = CallbackSet(events, save_events)
         end
     end
 
-    # Solve ensemble problem
-    solutions = daedalus_internal(
-        n_runs, shared_data, param_sets, cb_set
-    )
+    # Solve ensemble
+    ensemble_solution = daedalus_internal(length(r0_values), shared_data, param_sets, cb_set)
 
-    # return vector of results compatible with current output handlers
-    # NOTE: use EnsembleResult handling from SciMLBase later
-    results = [(sol = solutions[i], saves = _get_saved_vals_ensemble(npi),
-                   npi = npi, r0 = r0[i])
-               for i in 1:n_runs]
+    # Format results: Vector of NamedTuples, one per r0
+    results = []
+    for i in eachindex(r0_values)
+        saved_vals = if isnothing(npi)
+            nothing
+        elseif isa(npi, Npi)
+            npi.saved_values
+        else
+            nothing
+        end
+
+        push!(results, (sol = ensemble_solution[i], saves = saved_vals, npi = npi, r0 = r0_values[i]))
+    end
 
     return results
-end
-
-# Helper function to extract saved values from reactive NPIs
-function _get_saved_vals_ensemble(npi::Union{Npi, TimedNpi, Nothing})
-    if isnothing(npi)
-        return nothing
-    elseif isa(npi, Npi)
-        return npi.saved_values
-    else  # TimedNpi
-        return nothing
-    end
 end

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -122,10 +122,13 @@ function extract_infection_params(infection::DataLoader.InfectionData)::NamedTup
     # All economic groups use working-age parameters
     i_WORKING_AGE = 3  # 20-64 age group (third group, 1-indexed)
 
-    eta_expanded = [infection.eta; repeat([infection.eta[i_WORKING_AGE]], Constants.N_ECON_GROUPS)]
-    omega_expanded = [fill(0.012, Constants.N_AGE_GROUPS); repeat([0.012], Constants.N_ECON_GROUPS)]
+    eta_expanded = [infection.eta;
+                    repeat([infection.eta[i_WORKING_AGE]], Constants.N_ECON_GROUPS)]
+    omega_expanded = [fill(0.012, Constants.N_AGE_GROUPS);
+                      repeat([0.012], Constants.N_ECON_GROUPS)]
     gamma_H_val = infection.gamma_H_recovery  # Scalar value
-    gamma_H_expanded = [fill(gamma_H_val, Constants.N_AGE_GROUPS); repeat([gamma_H_val], Constants.N_ECON_GROUPS)]
+    gamma_H_expanded = [fill(gamma_H_val, Constants.N_AGE_GROUPS);
+                        repeat([gamma_H_val], Constants.N_ECON_GROUPS)]
 
     nu = 0.0  # Not user-configurable
 
@@ -275,14 +278,14 @@ function daedalus(country::Union{String, DataLoader.CountryData}, infection::Str
         time_end::Float64 = 100.0,
         increment::Float64 = 1.0,
         n_threads::Int = 1)
-
     infection_data = DataLoader.get_pathogen(lowercase(infection))
     return daedalus(country, infection_data; npi = npi, log_rt = log_rt,
-                    time_end = time_end, increment = increment, n_threads = n_threads)
+        time_end = time_end, increment = increment, n_threads = n_threads)
 end
 
 # Method 2: Single InfectionData object
-function daedalus(country::Union{String, DataLoader.CountryData}, infection::DataLoader.InfectionData;
+function daedalus(
+        country::Union{String, DataLoader.CountryData}, infection::DataLoader.InfectionData;
         npi::Union{Npi, TimedNpi, Nothing} = nothing,
         log_rt::Bool = true,
         time_end::Float64 = 100.0,
@@ -297,6 +300,7 @@ function daedalus(country::Union{String, DataLoader.CountryData}, infection::Dat
 
     # Prepare shared data once
     shared_data = prepare_shared_data(cd, time_end, increment)
+    shared_data.init_state[end] = inf_params.r0 # add R0 manually
 
     # Get country data for beta calculation
     contacts_unscaled = total_contacts(prepare_contacts(cd; scaled = false))

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -1,5 +1,5 @@
 
-export daedalus, prepare_shared_data, daedalus_internal
+export daedalus, prepare_shared_data, daedalus_internal, extract_infection_params
 
 using OrdinaryDiffEq  # consider even lighter deps
 using DiffEqCallbacks: SavingCallback, SavedValues, PresetTimeCallback
@@ -13,76 +13,136 @@ using .Helpers
 using .DaedalusStructs
 
 """
-    daedalus(country, r0; kwargs...)::Union{NamedTuple, Vector{NamedTuple}}
+    daedalus(country, infection; npi=nothing, log_rt=true, time_end=100.0, increment=1.0, n_threads=1)::Union{NamedTuple, Vector{NamedTuple}}
 
-Model the progression of an epidemic with optional multi-threading over parameter values.
+Model the progression of an epidemic with infection parameters and optional interventions.
 
 Solves the DAEDALUS compartmental epidemiological model for a specified country
-and basic reproduction number(s), with optional non-pharmaceutical interventions.
+and infection parameters, with optional non-pharmaceutical interventions.
 
 # Arguments
 - `country`: Country to model. Can be:
   - A `String` country name (e.g. `"Australia"`), looked up via `DataLoader.get_country`
   - A [`DataLoader.CountryData`](@ref) struct for custom or pre-fetched data
+- `infection`: Infection parameters. Can be:
+  - A `String` pathogen name (e.g. `"COVID-19"`), looked up via `DataLoader.get_pathogen`
+  - A [`DataLoader.InfectionData`](@ref) struct with all epidemiological parameters
+  - A `Vector{DataLoader.InfectionData}` for ensemble runs with multiple pathogens (R0s extracted)
 - `npi`: Non-pharmaceutical intervention. Can be:
   - `Npi`: Reactive NPI that responds to epidemic state (hospitalizations, Rt)
   - `TimedNpi`: Time-limited NPI with predefined start/end times
   - `nothing`: No intervention (default)
+- `log_rt`: Whether to compute and log effective reproduction number (default: true)
+- `time_end`: Simulation end time in days (default: 100.0)
+- `increment`: Savepoint interval in days (default: 1.0)
+- `n_threads`: Number of threads for multi-run execution (default: 1, ignored for scalar runs)
 
 # Examples
 
-## No intervention
+## String pathogen name
 ```julia
-result = daedalus("Australia", 2.5, time_end=200.0)
+result = daedalus("Australia", "sars-cov-2 delta", time_end=200.0)
 ```
 
 ## Using a pre-fetched CountryData struct
 ```julia
 cd = Daedalus.DataLoader.get_country("Australia")
-result = daedalus(cd, 2.5, time_end=200.0)
+result = daedalus(cd, "sars-cov-2 delta", time_end=200.0)
 ```
 
-## Single-phase time-limited intervention
+## InfectionData object with customization
 ```julia
-# 30% transmission reduction from day 15 to day 45
+infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+infection.r0 = 2.5  # Customize R0 if needed
+result = daedalus("Australia", infection, time_end=200.0)
+```
+
+## Time-limited intervention
+```julia
 npi = TimedNpi(15.0, 45.0, 0.7, "moderate_lockdown")
-result = daedalus("Australia", 2.5, time_end=200.0, npi=npi)
+result = daedalus("Australia", "sars-cov-2 delta", time_end=200.0, npi=npi)
 ```
 
-## Multi-phase time-limited intervention
+## Multiple pathogens with multi-threading
 ```julia
-# Three phases: moderate → strict → relaxed
-npi = TimedNpi(
-    [10.0, 30.0, 60.0],  # start times
-    [25.0, 55.0, 90.0],  # end times
-    [0.7, 0.3, 0.5],     # coefficients
-    "three_phase_strategy"
-)
-result = daedalus("Australia", 2.5, time_end=200.0, npi=npi)
-```
-
-## Reactive (state-dependent) intervention
-```julia
-# Triggers when hospitalizations reach threshold, deactivates when Rt < 1
-npi = Npi(5000.0, (coef=0.4,))
-result = daedalus("Australia", 2.5, time_end=200.0, npi=npi)
-```
-
-## Multiple R0 values with multi-threading
-```julia
-# Run model with multiple R0 values in parallel
-results = daedalus("Australia", [1.0, 2.0, 3.0], time_end=200.0)
-# Returns: Vector of results, one per R0 value
+infections = [
+    Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+    Daedalus.DataLoader.get_pathogen("influenza 2009")
+]
+results = daedalus("Australia", infections, time_end=200.0, n_threads=4)
 ```
 
 # Returns
-- Scalar r0: A `NamedTuple` with fields:
+- Scalar infection (String or InfectionData): A `NamedTuple` with fields:
   - `sol`: ODE solution object
   - `saves`: Saved values from reactive NPI (or nothing)
   - `npi`: The NPI used (or nothing)
-- Vector r0: A `Vector{NamedTuple}`, one per r0 value, with additional field:
+- Vector infection: A `Vector{NamedTuple}`, one per infection, with additional field:
   - `r0`: The r0 value for that run
 """
+
+"""
+    extract_infection_params(infection::DataLoader.InfectionData)::NamedTuple
+
+Extract and process epidemiological parameters from an InfectionData object.
+
+Converts base parameters to model-compatible form:
+- Expands age-varying parameters (eta, omega, gamma_H) to work with both
+  age groups (4) and economic groups (45), matching the 49-component state vector
+- Computes working-age indices for proper parameter replication
+
+# Arguments
+- `infection::DataLoader.InfectionData`: Infection parameters to extract
+
+# Returns
+A `NamedTuple` with fields:
+- `r0::Float64`: Basic reproduction number
+- `sigma::Float64`: Incubation rate (1/latent period)
+- `p_sigma::Float64`: Proportion symptomatic (presymptomatic transmission scaling)
+- `epsilon::Float64`: Relative transmissibility of asymptomatic cases
+- `rho::Float64`: Rate of infectiousness decay in hospitalized
+- `eta::Vector{Float64}`: Hospitalization rate (expanded to 49 groups)
+- `omega::Vector{Float64}`: Recovery rate for asymptomatic (expanded to 49 groups)
+- `gamma_Ia::Float64`: Recovery rate from asymptomatic infection
+- `gamma_Is::Float64`: Recovery rate from symptomatic infection
+- `gamma_H::Vector{Float64}`: Recovery rate for hospitalized (expanded to 49 groups)
+- `nu::Float64`: Fixed at 0.0 (not user-configurable)
+"""
+function extract_infection_params(infection::DataLoader.InfectionData)::NamedTuple
+    # Extract base parameters
+    r0 = infection.r0
+    sigma = infection.sigma
+    p_sigma = infection.p_sigma
+    epsilon = infection.epsilon
+    rho = infection.rho
+    gamma_Ia = infection.gamma_Ia
+    gamma_Is = infection.gamma_Is
+
+    # Expand age-varying parameters to 49 groups (4 age + 45 economic)
+    # All economic groups use working-age parameters
+    i_WORKING_AGE = 3  # 20-64 age group (third group, 1-indexed)
+
+    eta_expanded = [infection.eta; repeat([infection.eta[i_WORKING_AGE]], Constants.N_ECON_GROUPS)]
+    omega_expanded = [fill(0.012, Constants.N_AGE_GROUPS); repeat([0.012], Constants.N_ECON_GROUPS)]
+    gamma_H_val = infection.gamma_H_recovery  # Scalar value
+    gamma_H_expanded = [fill(gamma_H_val, Constants.N_AGE_GROUPS); repeat([gamma_H_val], Constants.N_ECON_GROUPS)]
+
+    nu = 0.0  # Not user-configurable
+
+    return (
+        r0 = r0,
+        sigma = sigma,
+        p_sigma = p_sigma,
+        epsilon = epsilon,
+        rho = rho,
+        eta = eta_expanded,
+        omega = omega_expanded,
+        gamma_Ia = gamma_Ia,
+        gamma_Is = gamma_Is,
+        gamma_H = gamma_H_expanded,
+        nu = nu
+    )
+end
 
 """
     prepare_shared_data(cd::DataLoader.CountryData, time_end::Float64,
@@ -208,85 +268,80 @@ function daedalus_internal(
     return solution
 end
 
-function daedalus(country::Union{String, DataLoader.CountryData}, r0::Float64;
-        sigma = 0.217,
-        p_sigma = 0.867,
-        epsilon = 0.58,
-        rho = 0.003,
-        eta::Vector{Float64} = [0.018, 0.082, 0.018, 0.246],
-        omega::Vector{Float64} = [0.012, 0.012, 0.012, 0.012],
-        gamma_Ia = 0.476,
-        gamma_Is = 0.25,
-        gamma_H::Vector{Float64} = [0.034, 0.034, 0.034, 0.034],
-        nu = 0.0,
-        psi::Float64 = 1.0 / 270.0,
+# Method 1: String pathogen name - fetch and delegate to InfectionData method
+function daedalus(country::Union{String, DataLoader.CountryData}, infection::String;
         npi::Union{Npi, TimedNpi, Nothing} = nothing,
-        log_rt = true,
+        log_rt::Bool = true,
         time_end::Float64 = 100.0,
-        increment::Float64 = 1.0)
+        increment::Float64 = 1.0,
+        n_threads::Int = 1)
 
-    # resolve country string to CountryData if needed
+    infection_data = DataLoader.get_pathogen(lowercase(infection))
+    return daedalus(country, infection_data; npi = npi, log_rt = log_rt,
+                    time_end = time_end, increment = increment, n_threads = n_threads)
+end
+
+# Method 2: Single InfectionData object
+function daedalus(country::Union{String, DataLoader.CountryData}, infection::DataLoader.InfectionData;
+        npi::Union{Npi, TimedNpi, Nothing} = nothing,
+        log_rt::Bool = true,
+        time_end::Float64 = 100.0,
+        increment::Float64 = 1.0,
+        n_threads::Int = 1)
+
+    # Extract infection parameters
+    inf_params = extract_infection_params(infection)
+
+    # Resolve country string to CountryData if needed
     cd = isa(country, String) ? DataLoader.get_country(country) : country
 
-    # get all values from country data
-    init_state = initial_state(cd)
+    # Prepare shared data once
+    shared_data = prepare_shared_data(cd, time_end, increment)
+
+    # Get country data for beta calculation
     contacts_unscaled = total_contacts(prepare_contacts(cd; scaled = false))
     cw = worker_contacts(cd)
 
-    # calculate beta
+    # Calculate beta with single r0
     beta = get_beta(
         contacts_unscaled,
-        r0, sigma, p_sigma, epsilon, gamma_Ia, gamma_Is
+        inf_params.r0, inf_params.sigma, inf_params.p_sigma,
+        inf_params.epsilon, inf_params.gamma_Ia, inf_params.gamma_Is
     )
-
-    # age varying parameters
-    eta = [eta; repeat([eta[i_WORKING_AGE]], N_ECON_GROUPS)]
-    omega = [omega; repeat([omega[i_WORKING_AGE]], N_ECON_GROUPS)]
-    gamma_H = [gamma_H; repeat([gamma_H[i_WORKING_AGE]], N_ECON_GROUPS)]
 
     # NGM
     ngm = get_ngm(
         contacts_unscaled,
-        beta, sigma, p_sigma, epsilon, gamma_Ia, gamma_Is
+        beta, inf_params.sigma, inf_params.p_sigma,
+        inf_params.epsilon, inf_params.gamma_Ia, inf_params.gamma_Is
     )
+
     demog = prepare_demog(cd)
-
     size::Int = N_TOTAL_GROUPS * N_COMPARTMENTS * N_VACCINE_STRATA
+    psi::Float64 = 1.0 / 270.0
 
-    # combined parameters into an array
+    # Create parameters struct
     contacts_array = contacts3d(cd)
     settings = get_settings(cd)
     cm_temp::Matrix{Float64} = ones(N_TOTAL_GROUPS, N_TOTAL_GROUPS)
-    parameters::Params = Params(contacts_array, cm_temp, settings, ngm, demog,
-        cw, beta, beta, sigma, p_sigma, epsilon, rho, eta, omega, omega,
-        gamma_Ia, gamma_Is, gamma_H, nu, psi,
-        size)
-
-    # prepare the timespan and savepoints
-    timespan = (0.0, time_end)
-    savepoints = 0.0:increment:time_end
-
-    # add Rt compartment at end
-    init_state = reshape(init_state, length(init_state))
-    init_state = [init_state; r0]
-
-    # define the ode problem
-    ode_problem = ODEProblem(
-        daedalus_ode!, init_state, timespan, parameters
+    parameters::Params = Params(
+        contacts_array, cm_temp, settings, ngm, demog,
+        cw, beta, beta, inf_params.sigma, inf_params.p_sigma,
+        inf_params.epsilon, inf_params.rho, inf_params.eta, inf_params.omega,
+        inf_params.omega, inf_params.gamma_Ia, inf_params.gamma_Is,
+        inf_params.gamma_H, inf_params.nu, psi, size
     )
 
-    # check if NPI is passed and define callbacks accordingly
+    # Build callback set
+    savepoints = shared_data.savepoints
     if isnothing(npi)
-        # No intervention
         cb_set = CallbackSet()
         if log_rt
             rt_logger = make_rt_logger(savepoints)
             cb_set = CallbackSet(rt_logger)
         end
     elseif isa(npi, TimedNpi)
-        # Time-limited NPI - purely time-based triggers
         timed_callbacks = make_timed_npi_callbacks(npi)
-
         if log_rt
             rt_logger = make_rt_logger(savepoints)
             cb_set = CallbackSet(timed_callbacks, rt_logger)
@@ -294,14 +349,11 @@ function daedalus(country::Union{String, DataLoader.CountryData}, r0::Float64;
             cb_set = timed_callbacks
         end
     elseif isa(npi, Npi)
-        # Reactive NPI - state-dependent triggers
         coef = get_coef(npi)
         fn_effect_on = make_param_changer("beta", .*, coef)
         fn_effect_off = make_param_reset("beta")
-
         save_events = make_save_events(npi, savepoints)
         events = make_events(npi, fn_effect_on, fn_effect_off, savepoints)
-
         if log_rt
             rt_logger = make_rt_logger(savepoints)
             cb_set = CallbackSet(events, save_events, rt_logger)
@@ -310,15 +362,17 @@ function daedalus(country::Union{String, DataLoader.CountryData}, r0::Float64;
         end
     end
 
-    # get the solution
+    # Solve for scalar case
+    ode_problem = ODEProblem(
+        daedalus_ode!, shared_data.init_state, shared_data.timespan, parameters
+    )
     ode_solution = solve(ode_problem, callback = cb_set, saveat = savepoints)
 
-    # Handle saved values - only reactive NPIs have saved_values
     saved_vals = if isnothing(npi)
         nothing
     elseif isa(npi, Npi)
         npi.saved_values
-    else  # TimedNpi
+    else
         nothing
     end
 

--- a/test/test_basic.jl
+++ b/test/test_basic.jl
@@ -1,6 +1,8 @@
 @testset "DAEDALUS model" begin
     try
-        daedalus("Australia", 5.0, time_end = 100.0)
+        infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        infection.r0 = 5.0
+        daedalus("Australia", infection, time_end = 100.0)
         @test true
     catch e
         @test false
@@ -9,12 +11,16 @@ end
 
 @testset "daedalus accepts CountryData struct" begin
     cd = Daedalus.DataLoader.get_country("Australia")
-    result = daedalus(cd, 3.0, time_end = 100.0, log_rt = false)
+    infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+    infection.r0 = 3.0
+    result = daedalus(cd, infection, time_end = 100.0, log_rt = false)
     @test length(result.sol.t) == 101
     @test all(isfinite, result.sol.u[end])
 
     # result must be identical to string-based call
-    result_str = daedalus("Australia", 3.0, time_end = 100.0, log_rt = false)
+    infection_str = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+    infection_str.r0 = 3.0
+    result_str = daedalus("Australia", infection_str, time_end = 100.0, log_rt = false)
     @test result.sol.u[end] ≈ result_str.sol.u[end]
 end
 

--- a/test/test_countries.jl
+++ b/test/test_countries.jl
@@ -19,7 +19,9 @@
         @test all(isfinite, cm)
 
         # ODE must solve without NaN/Inf in the solution
-        result = daedalus(country, 3.0, time_end = 100.0, log_rt = false)
+        infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        infection.r0 = 3.0
+        result = daedalus(country, infection, time_end = 100.0, log_rt = false)
         last_u = result.sol.u[end]
 
         @test length(result.sol.t) == 101 # hardcoded but oh well

--- a/test/test_eigenvalue.jl
+++ b/test/test_eigenvalue.jl
@@ -174,13 +174,15 @@ end
 @testset "Rt calculation in make_rt_logger" begin
     @testset "Rt logging with power iteration" begin
         # Run a short simulation with Rt logging enabled
+        infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        infection.r0 = 2.0
         result = Daedalus.daedalus(
             "Australia",
-            2.0,
+            infection,
             time_end = 50.0,
             increment = 1.0,
             log_rt = true
-        )
+        );
 
         # Extract Rt values
         iRt = Daedalus.Constants.get_indices("Rt")
@@ -202,9 +204,11 @@ end
         # Create a simple NPI for testing
         npi = Daedalus.DaedalusStructs.Npi(20000.0, (coef = 0.7,))
 
+        infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        infection.r0 = 3.0
         result = Daedalus.daedalus(
             "Australia",
-            3.0,
+            infection,
             time_end = 100.0,
             increment = 1.0,
             npi = npi,

--- a/test/test_multi_runs.jl
+++ b/test/test_multi_runs.jl
@@ -6,10 +6,12 @@ Tests basic functionality and structure without checking numerical correctness.
 using Daedalus
 using Test
 
-@testset "Multi-run r0 parameter support" begin
-    @testset "Scalar r0 returns single result" begin
-        # Scalar r0 should return a single NamedTuple, not a vector
-        result = Daedalus.daedalus("Canada", 1.5, time_end = 10.0)
+@testset "Multi-run infection parameter support" begin
+    @testset "Scalar infection returns single result" begin
+        # Scalar infection should return a single NamedTuple, not a vector
+        infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        infection.r0 = 1.5
+        result = Daedalus.daedalus("Canada", infection, time_end = 10.0)
 
         @test isa(result, NamedTuple)
         @test haskey(result, :sol)
@@ -18,10 +20,17 @@ using Test
         @test length(result) == 3  # sol, saves, npi only
     end
 
-    @testset "Vector r0 returns vector of results" begin
-        # Vector r0 should return a Vector of NamedTuples
-        r0_vals = [1.0, 1.5, 2.0]
-        results = Daedalus.daedalus("Canada", r0_vals, time_end = 10.0)
+    @testset "Vector infection returns vector of results" begin
+        # Vector infection should return a Vector of NamedTuples
+        infections = [
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        ]
+        infections[1].r0 = 1.0
+        infections[2].r0 = 1.5
+        infections[3].r0 = 2.0
+        results = Daedalus.daedalus("Canada", infections, time_end = 10.0)
 
         @test isa(results, Vector)
         @test length(results) == 3
@@ -33,17 +42,20 @@ using Test
             @test haskey(result, :saves)
             @test haskey(result, :npi)
             @test haskey(result, :r0)
-            @test result.r0 == r0_vals[i]
+            @test result.r0 == infections[i].r0
         end
     end
 
-    @testset "Single-element r0 vector matches scalar" begin
-        # A vector with one element should behave like scalar
-        r0_scalar = 1.5
-        r0_vector = [1.5]
+    @testset "Single-element infection vector matches scalar" begin
+        # A vector with one element should behave like vector
+        infection_scalar = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        infection_scalar.r0 = 1.5
 
-        result_scalar = Daedalus.daedalus(country = "Canada", r0 = r0_scalar, time_end = 10.0)
-        results_vector = Daedalus.daedalus(country = "Canada", r0 = r0_vector, time_end = 10.0)
+        infections_vector = [Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")]
+        infections_vector[1].r0 = 1.5
+
+        result_scalar = Daedalus.daedalus("Canada", infection_scalar, time_end = 10.0)
+        results_vector = Daedalus.daedalus("Canada", infections_vector, time_end = 10.0)
 
         # Vector should return a vector of length 1
         @test isa(results_vector, Vector)
@@ -51,13 +63,18 @@ using Test
 
         # The single result should be a NamedTuple with the r0 parameter field
         @test isa(results_vector[1], NamedTuple)
-        @test results_vector[1].r0 == r0_scalar
+        @test results_vector[1].r0 == infection_scalar.r0
     end
 
     @testset "Different r0 values produce different results" begin
         # Different r0 values should produce different ODE solutions
-        r0_vals = [1.0, 3.0]
-        results = Daedalus.daedalus(country = "Canada", r0 = r0_vals, time_end = 50.0)
+        infections = [
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        ]
+        infections[1].r0 = 1.0
+        infections[2].r0 = 3.0
+        results = Daedalus.daedalus("Canada", infections, time_end = 50.0)
 
         @test length(results) == 2
 
@@ -72,12 +89,19 @@ using Test
 
     @testset "Time dimension consistency" begin
         # All runs should have same number of timepoints
-        r0_vals = [1.0, 2.0, 3.0]
+        infections = [
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        ]
+        infections[1].r0 = 1.0
+        infections[2].r0 = 2.0
+        infections[3].r0 = 3.0
         time_end = 30.0
         increment = 1.0
 
         results = Daedalus.daedalus(
-            country = "Canada", r0 = r0_vals, time_end = time_end, increment = increment
+            "Canada", infections, time_end = time_end, increment = increment
         )
 
         expected_timepoints = Int(time_end / increment) + 1
@@ -92,9 +116,16 @@ end
 @testset "Multi-threading support" begin
     @testset "Serial execution (n_threads=1)" begin
         # With n_threads=1, should execute serially without error
-        r0_vals = [1.0, 1.5, 2.0]
+        infections = [
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        ]
+        infections[1].r0 = 1.0
+        infections[2].r0 = 1.5
+        infections[3].r0 = 2.0
         results = Daedalus.daedalus(
-            "Canada", r0_vals, time_end = 10.0, n_threads = 1
+            "Canada", infections, time_end = 10.0, n_threads = 1
         )
 
         @test isa(results, Vector)
@@ -108,11 +139,18 @@ end
 
     @testset "Multi-threaded execution (n_threads>1)" begin
         # With n_threads>1, should execute with threads without error
-        r0_vals = [1.0, 1.5, 2.0]
+        infections = [
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        ]
+        infections[1].r0 = 1.0
+        infections[2].r0 = 1.5
+        infections[3].r0 = 2.0
         n_threads_use = min(4, Threads.nthreads())  # Use up to 4 threads, but not more than available
 
         results = Daedalus.daedalus(
-            "Canada", r0_vals, time_end = 10.0, n_threads = n_threads_use
+            "Canada", infections, time_end = 10.0, n_threads = n_threads_use
         )
 
         @test isa(results, Vector)
@@ -126,16 +164,32 @@ end
 
     @testset "Serial and multi-threaded produce consistent results" begin
         # Results should be identical regardless of threading
-        r0_vals = [1.0, 1.5, 2.0]
+        infections_serial = [
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        ]
+        infections_serial[1].r0 = 1.0
+        infections_serial[2].r0 = 1.5
+        infections_serial[3].r0 = 2.0
 
         results_serial = Daedalus.daedalus(
-            "Canada", r0_vals, time_end = 10.0, n_threads = 1
+            "Canada", infections_serial, time_end = 10.0, n_threads = 1
         )
 
         n_threads_use = min(2, Threads.nthreads())
         if n_threads_use > 1
+            infections_threaded = [
+                Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+                Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+                Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+            ]
+            infections_threaded[1].r0 = 1.0
+            infections_threaded[2].r0 = 1.5
+            infections_threaded[3].r0 = 2.0
+
             results_threaded = Daedalus.daedalus(
-                "Canada", r0_vals, time_end = 10.0, n_threads = n_threads_use
+                "Canada", infections_threaded, time_end = 10.0, n_threads = n_threads_use
             )
 
             @test length(results_serial) == length(results_threaded)
@@ -152,8 +206,10 @@ end
     end
 
     @testset "n_threads=1 default for scalar" begin
-        # When using scalar r0, n_threads parameter should be ignored (no effect)
-        result = Daedalus.daedalus("Canada", 1.5, time_end = 10.0, n_threads = 4)
+        # When using scalar infection, n_threads parameter should be ignored (no effect)
+        infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        infection.r0 = 1.5
+        result = Daedalus.daedalus("Canada", infection, time_end = 10.0, n_threads = 4)
 
         # Should still return single result, not vector
         @test isa(result, NamedTuple)
@@ -162,17 +218,21 @@ end
 end
 
 @testset "Edge cases" begin
-    @testset "Empty r0 vector raises error" begin
+    @testset "Empty infection vector raises error" begin
         # Empty vector should raise an error
         @test_throws BoundsError Daedalus.daedalus(
-            "Canada", Float64[], time_end = 10.0
+            "Canada", Daedalus.DataLoader.InfectionData[], time_end = 10.0
         )
     end
 
-    @testset "Large r0 vector" begin
+    @testset "Large infection vector" begin
         # Should handle moderate-sized parameter sweeps
         r0_vals = collect(1.0:0.5:10.0)  # 19 values
-        results = Daedalus.daedalus("Canada", r0_vals, time_end = 5.0)
+        infections = [Daedalus.DataLoader.get_pathogen("sars-cov-2 delta") for _ in r0_vals]
+        for (i, r0) in enumerate(r0_vals)
+            infections[i].r0 = r0
+        end
+        results = Daedalus.daedalus("Canada", infections, time_end = 5.0)
 
         @test length(results) == length(r0_vals)
 
@@ -184,8 +244,13 @@ end
 
     @testset "Very small time_end" begin
         # Should handle very short simulation times
-        r0_vals = [1.0, 2.0]
-        results = Daedalus.daedalus("Canada", r0_vals, time_end = 1.0)
+        infections = [
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        ]
+        infections[1].r0 = 1.0
+        infections[2].r0 = 2.0
+        results = Daedalus.daedalus("Canada", infections, time_end = 1.0)
 
         @test length(results) == 2
         for result in results
@@ -194,13 +259,21 @@ end
         end
     end
 
-    @testset "Different countries with vector r0" begin
+    @testset "Different countries with vector infection" begin
         # Should work with different country data
         countries = ["Australia", "United Kingdom"]
-        r0_vals = [1.0, 2.0, 3.0]
+        infections_template = [
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        ]
 
         for country_name in countries
-            results = Daedalus.daedalus(country_name, r0_vals, time_end = 5.0)
+            infections = [Daedalus.DataLoader.get_pathogen("sars-cov-2 delta") for _ in 1:3]
+            infections[1].r0 = 1.0
+            infections[2].r0 = 2.0
+            infections[3].r0 = 3.0
+            results = Daedalus.daedalus(country_name, infections, time_end = 5.0)
             @test length(results) == 3
         end
     end
@@ -209,7 +282,11 @@ end
 @testset "Parameter preservation" begin
     @testset "r0 values are correctly stored in results" begin
         r0_vals = [1.2, 2.3, 3.4]
-        results = Daedalus.daedalus("Canada", r0_vals, time_end = 10.0)
+        infections = [Daedalus.DataLoader.get_pathogen("sars-cov-2 delta") for _ in r0_vals]
+        for (i, r0) in enumerate(r0_vals)
+            infections[i].r0 = r0
+        end
+        results = Daedalus.daedalus("Canada", infections, time_end = 10.0)
 
         for (i, result) in enumerate(results)
             @test result.r0 == r0_vals[i]
@@ -217,10 +294,15 @@ end
     end
 
     @testset "Other parameters are shared across runs" begin
-        r0_vals = [1.0, 2.0]
+        infections = [
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        ]
+        infections[1].r0 = 1.0
+        infections[2].r0 = 2.0
         results = Daedalus.daedalus(
             "Canada",
-            r0_vals,
+            infections,
             time_end = 10.0,
             npi = nothing,
             log_rt = true
@@ -234,8 +316,13 @@ end
 
 @testset "Solution structure" begin
     @testset "Each solution has valid ODE output" begin
-        r0_vals = [1.0, 2.0]
-        results = Daedalus.daedalus("Canada", r0_vals, time_end = 15.0)
+        infections = [
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta"),
+            Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        ]
+        infections[1].r0 = 1.0
+        infections[2].r0 = 2.0
+        results = Daedalus.daedalus("Canada", infections, time_end = 15.0)
 
         for result in results
             sol = result.sol
@@ -254,8 +341,9 @@ end
 
     @testset "Solutions have correct state dimension" begin
         # State should have N_COMPARTMENTS * N_TOTAL_GROUPS * N_VACCINE_STRATA + 1 (for Rt)
-        r0_vals = [1.0]
-        results = Daedalus.daedalus("Canada", r0_vals, time_end = 10.0)
+        infections = [Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")]
+        infections[1].r0 = 1.0
+        results = Daedalus.daedalus("Canada", infections, time_end = 10.0)
 
         state = results[1].sol.u[1]
         expected_dim = Daedalus.Constants.N_COMPARTMENTS *
@@ -266,13 +354,30 @@ end
     end
 end
 
-@testset "Backward compatibility" begin
-    @testset "Scalar r0 behavior unchanged" begin
-        # Original scalar interface should work exactly as before
+@testset "New interface with InfectionData" begin
+    @testset "String pathogen name works" begin
+        # String pathogen should fetch and work
         result = Daedalus.daedalus(
             "Australia",
-            2.0,
-            sigma = 0.217,
+            "sars-cov-2 delta",
+            time_end = 20.0,
+            log_rt = true
+        )
+
+        @test isa(result, NamedTuple)
+        @test haskey(result, :sol)
+        @test haskey(result, :saves)
+        @test haskey(result, :npi)
+        @test length(result) == 3  # Only sol, saves, npi (no r0 field)
+    end
+
+    @testset "InfectionData object works" begin
+        # InfectionData object should work directly
+        infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        infection.r0 = 2.0
+        result = Daedalus.daedalus(
+            "Australia",
+            infection,
             time_end = 20.0,
             log_rt = true
         )

--- a/test/test_outputs.jl
+++ b/test/test_outputs.jl
@@ -1,5 +1,7 @@
 @testset "Outputs.get_values" begin
-    output = daedalus("Australia", 2.5, time_end = 100.0)
+    infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+    infection.r0 = 2.5
+    output = daedalus("Australia", infection, time_end = 100.0)
     tmax = 100
 
     @testset "daily values (timebin=1)" begin
@@ -19,7 +21,9 @@
     end
 
     @testset "bin alignment when tmax divisible by timebin" begin
-        output90 = daedalus("Australia", 2.5, time_end = 90.0)
+        infection90 = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        infection90.r0 = 2.5
+        output90 = daedalus("Australia", infection90, time_end = 90.0)
         daily = Daedalus.Outputs.get_values(output90, "H", 1)
         binned = Daedalus.Outputs.get_values(output90, "H", 90)
         @test length(binned) == 1

--- a/test/test_settings.jl
+++ b/test/test_settings.jl
@@ -38,7 +38,9 @@
     @testset "daedalus runs with two equal settings" begin
         cd2 = deepcopy(cd)
         cd2.contact_matrix = [cm, cm]
-        result = daedalus(cd2, 2.5, time_end = 100.0, log_rt = false)
+        infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        infection.r0 = 2.5
+        result = daedalus(cd2, infection, time_end = 100.0, log_rt = false)
         @test length(result.sol.t) == 101
         @test all(isfinite, result.sol.u[end])
     end
@@ -53,9 +55,12 @@
         # the same r0 is used.
         cd2 = deepcopy(cd)
         cd2.contact_matrix = [cm, cm]
-        r0 = 2.5
-        result_1 = daedalus(cd, r0, time_end = 300.0, log_rt = false)
-        result_2 = daedalus(cd2, r0, time_end = 300.0, log_rt = false)
+        infection_1 = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        infection_1.r0 = 2.5
+        infection_2 = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        infection_2.r0 = 2.5
+        result_1 = daedalus(cd, infection_1, time_end = 300.0, log_rt = false)
+        result_2 = daedalus(cd2, infection_2, time_end = 300.0, log_rt = false)
         deaths_1 = last(Daedalus.Outputs.get_values(result_1, "D", 1))
         deaths_2 = last(Daedalus.Outputs.get_values(result_2, "D", 1))
         @test deaths_2 ≈ deaths_1 rtol = 1e-3

--- a/test/test_timed_npi.jl
+++ b/test/test_timed_npi.jl
@@ -255,7 +255,7 @@ end
 
         result = Daedalus.daedalus(
             "Australia",
-            2.5,
+            "sars-cov-1",
             time_end = 100.0,
             increment = 1.0,
             npi = npi,
@@ -272,7 +272,7 @@ end
 
         result = Daedalus.daedalus(
             "Australia",
-            1.8,
+            "sars-cov-1",
             time_end = 60.0,
             npi = npi,
             log_rt = false
@@ -286,7 +286,7 @@ end
 
         result = Daedalus.daedalus(
             "Australia",
-            2.0,
+            "sars-cov-1",
             time_end = 50.0,
             increment = 1.0,
             npi = npi
@@ -303,7 +303,7 @@ end
 
         result = Daedalus.daedalus(
             "Australia",
-            2.0,
+            "influenza 2009",
             time_end = 50.0,
             increment = 1.0,
             npi = npi
@@ -320,7 +320,7 @@ end
         npi_block = Daedalus.DaedalusStructs.TimedNpi(10.0, 30.0, 0.0)
         result_block = Daedalus.daedalus(
             "Australia",
-            3.0,
+            "influenza 2009",
             time_end = 50.0,
             npi = npi_block
         )
@@ -330,7 +330,7 @@ end
         npi_none = Daedalus.DaedalusStructs.TimedNpi(10.0, 30.0, 1.0)
         result_none = Daedalus.daedalus(
             "Australia",
-            3.0,
+            "influenza 2009",
             time_end = 50.0,
             npi = npi_none
         )
@@ -342,7 +342,7 @@ end
         npi_start = Daedalus.DaedalusStructs.TimedNpi(0.0, 20.0, 0.5)
         result_start = Daedalus.daedalus(
             "Australia",
-            2.0,
+            "influenza 2009",
             time_end = 40.0,
             npi = npi_start
         )
@@ -352,7 +352,7 @@ end
         npi_end = Daedalus.DaedalusStructs.TimedNpi(20.0, 50.0, 0.5)
         result_end = Daedalus.daedalus(
             "Australia",
-            2.0,
+            "influenza 2009",
             time_end = 50.0,
             npi = npi_end
         )
@@ -362,7 +362,7 @@ end
         npi_full = Daedalus.DaedalusStructs.TimedNpi(0.0, 50.0, 0.5)
         result_full = Daedalus.daedalus(
             "Australia",
-            2.0,
+            "influenza 2009",
             time_end = 50.0,
             npi = npi_full
         )
@@ -375,7 +375,7 @@ end
         # Run without intervention
         result_none = Daedalus.daedalus(
             "Australia",
-            2.5,
+            "influenza 2009",
             time_end = 100.0,
             increment = 1.0,
             log_rt = true
@@ -385,7 +385,7 @@ end
         npi = Daedalus.DaedalusStructs.TimedNpi(20.0, 60.0, 0.3)
         result_npi = Daedalus.daedalus(
             "Australia",
-            2.5,
+            "influenza 2009",
             time_end = 100.0,
             increment = 1.0,
             npi = npi,
@@ -416,7 +416,7 @@ end
 
         result = Daedalus.daedalus(
             "Australia",
-            2.5,
+            "influenza 2009",
             time_end = 100.0,
             npi = npi
         )
@@ -429,7 +429,7 @@ end
     @testset "Model accepts nothing (unchanged behavior)" begin
         result = Daedalus.daedalus(
             "Australia",
-            2.0,
+            "influenza 2009",
             time_end = 50.0,
             npi = nothing
         )
@@ -446,7 +446,7 @@ end
         npi = Daedalus.DaedalusStructs.TimedNpi(20.0, 20.1, 0.5)
         result = Daedalus.daedalus(
             "Australia",
-            2.0,
+            "influenza 2009",
             time_end = 40.0,
             increment = 0.1,
             npi = npi
@@ -459,7 +459,7 @@ end
         npi = Daedalus.DaedalusStructs.TimedNpi(10.0, 210.0, 0.3)
         result = Daedalus.daedalus(
             "Australia",
-            2.0,
+            "influenza 2009",
             time_end = 250.0,
             npi = npi
         )
@@ -477,7 +477,7 @@ end
         )
         result = Daedalus.daedalus(
             "Australia",
-            2.0,
+            "influenza 2009",
             time_end = 120.0,
             npi = npi
         )
@@ -495,7 +495,7 @@ end
         )
         result = Daedalus.daedalus(
             "Australia",
-            2.5,
+            "sars-cov-1",
             time_end = 100.0,
             npi = npi
         )
@@ -507,7 +507,7 @@ end
         npi = Daedalus.DaedalusStructs.TimedNpi(5.0, 50.0, 0.1)
         result = Daedalus.daedalus(
             "Australia",
-            5.0,
+            "sars-cov-1",
             time_end = 80.0,
             npi = npi
         )
@@ -519,7 +519,7 @@ end
         npi = Daedalus.DaedalusStructs.TimedNpi(150.0, 180.0, 0.3)
         result = Daedalus.daedalus(
             "Australia",
-            2.0,
+            "influenza 2009",
             time_end = 200.0,
             npi = npi
         )

--- a/test/test_timed_npi.jl
+++ b/test/test_timed_npi.jl
@@ -228,10 +228,12 @@ end
 @testset "TimedNpi integration with daedalus model" begin
     @testset "Model runs with single-phase TimedNpi" begin
         npi = Daedalus.DaedalusStructs.TimedNpi(15.0, 45.0, 0.5, "test_single")
+        infection_single = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        infection_single.r0 = 2.0
 
         result = Daedalus.daedalus(
             "Australia",
-            2.0,
+            infection_single,
             time_end = 80.0,
             increment = 1.0,
             npi = npi,


### PR DESCRIPTION
This PR brings Daedalus.jl more in line with {daedalus} by allowing infection parameters to be grouped together into an `InfectionData` struct and passed to `daedalus`; alternatively, as a string.

One issue to note is that running `daedalus` with multiple infection param sets breaks the R_t logging for t = 0.0, which might also break any reactive NPIs, but that's something that can be sorted later.