### PR TITLE
Unify NPI implementaion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.10] - 20266-04-09
+
+### Changed (Breaking)
+- Simplified public API by hiding internal trigger state representation:
+  - Removed from exports: `ReactiveEffect`, `TimedEffect`, `StateData`, `CtStateData`, `DsStateData`, `get_indices`
+  - Added to exports: `Effect` (abstract type), `ParamEffect` (concrete effect type), `Trigger` (abstract type), `ReactiveTrigger`, `TimeTrigger` (concrete trigger types)
+  - Internal state tracking now uses abstract `Trigger` type instead of concrete `StateData` subtypes
+- Trigger constructor parameter order changed (breaking change for direct instantiation):
+  - `ReactiveTrigger(name, value)` → `ReactiveTrigger(value, name)` (value now first positional argument)
+  - `TimeTrigger(name="time", value)` → `TimeTrigger(value, name="time")` (value now first positional argument)
+- Removed convenience constructor: `ReactiveEffect(target, func, reset_func; on=(...), off=(...))` — use full `ParamEffect` constructor with explicit `ReactiveTrigger`/`TimeTrigger` objects instead
+- Removed public function: `get_indices(x::StateData)` — internal helper no longer exported
+- Refactored `make_param_changer(eff::Effect)` and `make_param_reset(eff::Effect)` to dispatch on `Trigger` type using `isa(eff.trigger_on, TimeTrigger)` instead of string comparison on trigger names
+
 ## [0.0.9] - 2026-04-01
 
 ### Changed (Breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.9] - 2026-04-01
+
+### Changed (Breaking)
+- Unified NPI types: `Npi` is now the single container for all parameter effects (both reactive and timed)
+  - `abstract type Effect` renamed to `abstract type ParamEffect`
+  - `ParamEffect` struct renamed to `ReactiveEffect` — state-dependent interventions with independent on/off triggers
+  - New `TimedEffect <: ParamEffect` struct for time-limited interventions (replaces `TimedNpi`)
+    - Constructor: `TimedEffect(target, func, reset_func, start_time, end_time)`
+    - Example: `TimedEffect(:beta, x -> x .* 0.7, x -> x ./ 0.7, 10.0, 40.0)`
+  - `Npi` now accepts both `ReactiveEffect` and `TimedEffect` objects via `Npi(effects::AbstractVector{<:ParamEffect})`
+    - Unified callback handling: `make_events(npi, savepoints)` dispatches per effect type
+  - `TimedNpi` struct removed; use `Npi([TimedEffect(...)])` instead
+  - Removed public functions: `n_phases`, `total_duration`, `make_timed_npi_callbacks`
+  - Removed public type: `TimedNpi`
+- Behavior changes:
+  - `result.saves` now only contains `SavedValues` for `ReactiveEffect` entries (skips `TimedEffect`)
+  - `Union{Npi, TimedNpi, Nothing}` type annotations throughout codebase replaced with `Union{Npi, Nothing}`
+  - `make_param_changer(eff::ParamEffect)` and `make_param_reset(eff::ParamEffect)` now dispatch on specific effect types
+  - `make_save_events(npi::Npi)` skips `TimedEffect` entries (no state-based saving needed for timed interventions)
+
 ## [0.0.8] - 2026-03-31
 
 ### Changed (Breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (Breaking)
 - Added struct `ParamEffect` to define NPI target parameter and launch and end triggers
+  - New constructor: `ParamEffect(target, func, reset_func; on=(...), off=(...))`
+  - `func`: Transformation function applied when effect is active (e.g., `x -> x .* 0.4` for 60% reduction)
+  - `reset_func`: Inverse function to restore parameter when effect deactivates (e.g., `x -> x ./ 0.4`)
+  - Example: `ParamEffect(:beta, x -> x .* 0.4, x -> x ./ 0.4; on=("H", 5000.0), off=("Rt", 1.0))`
 - Struct `Npi` simplified to a container of `Vector{ParamEffect}`
   - Removed fields: `params` (NpiData), `saved_values`, `ison` — all now per-effect
   - New primary constructor: `Npi(effects::Vector{ParamEffect})` for custom per-effect triggers

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Daedalus"
 uuid = "05fc9732-d2bf-478b-9a56-f88318f7a02f"
 authors = ["Pratik Gupte <pratikgupte16@gmail.com> and contributors"]
-version = "0.0.8"
+version = "0.0.9"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Daedalus.jl
 
 [![License:MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/version-0.0.8-aquamarine.svg)](https://jameel-institute.github.io/Daedalus.jl/dev/)
+[![Version](https://img.shields.io/badge/version-0.0.9-aquamarine.svg)](https://jameel-institute.github.io/Daedalus.jl/dev/)
 [![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://jameel-institute.github.io/Daedalus.jl/dev/)
 [![Build Status](https://github.com/jameel-institute/Daedalus.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/jameel-institute/Daedalus.jl/actions/workflows/CI.yml?query=branch%3Amain)
@@ -31,7 +31,6 @@ using Plots
 
 # pump up r0 to get peak within 50 days
 infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
-infection.r0 = 5.0
 data = daedalus("Canada", infection, time_end=600.0);
 
 # plot exposed group

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -303,7 +303,7 @@ version = "4.1.1"
 deps = ["CSV", "DataFrames", "DiffEqCallbacks", "LinearAlgebra", "OrdinaryDiffEq", "SciMLBase", "StaticArrays", "Statistics"]
 path = ".."
 uuid = "05fc9732-d2bf-478b-9a56-f88318f7a02f"
-version = "0.0.8"
+version = "0.0.9"
 
 [[deps.DataAPI]]
 git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
@@ -1413,9 +1413,9 @@ version = "1.8.1"
 
 [[deps.OrdinaryDiffEq]]
 deps = ["ADTypes", "Adapt", "ArrayInterface", "CommonSolve", "DataStructures", "DiffEqBase", "DocStringExtensions", "EnumX", "ExponentialUtilities", "FastBroadcast", "FastClosures", "FillArrays", "FiniteDiff", "ForwardDiff", "FunctionWrappersWrappers", "InteractiveUtils", "LineSearches", "LinearAlgebra", "LinearSolve", "Logging", "MacroTools", "MuladdMacro", "NonlinearSolve", "OrdinaryDiffEqAdamsBashforthMoulton", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqDefault", "OrdinaryDiffEqDifferentiation", "OrdinaryDiffEqExplicitRK", "OrdinaryDiffEqExponentialRK", "OrdinaryDiffEqExtrapolation", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqFeagin", "OrdinaryDiffEqFunctionMap", "OrdinaryDiffEqHighOrderRK", "OrdinaryDiffEqIMEXMultistep", "OrdinaryDiffEqLinear", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqLowStorageRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqNordsieck", "OrdinaryDiffEqPDIRK", "OrdinaryDiffEqPRK", "OrdinaryDiffEqQPRK", "OrdinaryDiffEqRKN", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqSSPRK", "OrdinaryDiffEqStabilizedIRK", "OrdinaryDiffEqStabilizedRK", "OrdinaryDiffEqSymplecticRK", "OrdinaryDiffEqTsit5", "OrdinaryDiffEqVerner", "Polyester", "PreallocationTools", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLOperators", "SciMLStructures", "SimpleNonlinearSolve", "SparseArrays", "Static", "StaticArrayInterface", "StaticArrays", "TruncatedStacktraces"]
-git-tree-sha1 = "47271adac597af08263b6ea2669e93040b45c4d0"
+git-tree-sha1 = "621790374f3945db30f871313c131e5b9c956f63"
 uuid = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-version = "6.111.0"
+version = "6.109.0"
 
 [[deps.OrdinaryDiffEqAdamsBashforthMoulton]]
 deps = ["DiffEqBase", "FastBroadcast", "MuladdMacro", "OrdinaryDiffEqCore", "OrdinaryDiffEqLowOrderRK", "Polyester", "RecursiveArrayTools", "Reexport", "SciMLBase", "Static"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,14 +21,12 @@ makedocs(;
     pages = [
         "Home" => "index.md",
         "Modelling parameter uncertainty" => "ensemble.md",
-        "Implementing interventions" => "npis.md",
         "Time-dependent interventions" => "time_dep_npis.md",
         "State-dependent interventions" => "state_dep_npis.md",
         "Multiple contact settings" => "settings.md",
         "Benchmarking" => "benchmarking.md",
         "Parallelisation" => "parallelisation.md",
         "Country and pathogen data" => "country_data.md",
-        "Implementing reactive events" => "musings.md",
         "Index" => "pkg_index.md",
         "Function Reference" => "reference.md"
     ]

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -52,12 +52,13 @@ using Daedalus
 using BenchmarkTools
 
 # Create a reactive NPI: reduce transmission when hospitalizations exceed 20,000
+trigger_on = Daedalus.DaedalusStructs.ReactiveTrigger(20000.0, "H")
+trigger_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
 effect = Daedalus.DaedalusStructs.ParamEffect(
     :beta,
     x -> x .* 0.3,      # 70% reduction
-    x -> x ./ 0.3;      # reset: divide by 0.3
-    on = ("H", 20000.0),
-    off = ("Rt", 1.0)
+    x -> x ./ 0.3,      # reset: divide by 0.3
+    trigger_on, trigger_off
 )
 npi = Daedalus.DaedalusStructs.Npi([effect])
 
@@ -80,12 +81,25 @@ infection_re2.r0 = 5.0
 using Daedalus
 using BenchmarkTools
 
-timed_npi = Daedalus.DaedalusStructs.TimedNpi(
-    [60.0, 180.0, 300.0],
-    [120.0, 200.0, 365.0],
-    [0.3, 0.7, 0.5],
-    "three_phase_lockdown"
-)
+# Create three-phase time-based NPI with different reductions
+effects = [
+    Daedalus.DaedalusStructs.ParamEffect(
+        :beta, x -> x .* 0.7, x -> x ./ 0.7,
+        Daedalus.DaedalusStructs.TimeTrigger(60.0),
+        Daedalus.DaedalusStructs.TimeTrigger(120.0)
+    ),
+    Daedalus.DaedalusStructs.ParamEffect(
+        :beta, x -> x .* 0.3, x -> x ./ 0.3,
+        Daedalus.DaedalusStructs.TimeTrigger(180.0),
+        Daedalus.DaedalusStructs.TimeTrigger(200.0)
+    ),
+    Daedalus.DaedalusStructs.ParamEffect(
+        :beta, x -> x .* 0.5, x -> x ./ 0.5,
+        Daedalus.DaedalusStructs.TimeTrigger(300.0),
+        Daedalus.DaedalusStructs.TimeTrigger(365.0)
+    )
+]
+timed_npi = Daedalus.DaedalusStructs.Npi(effects)
 
 infection_te = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
 infection_te.r0 = 3.0

--- a/docs/src/benchmarking.md
+++ b/docs/src/benchmarking.md
@@ -54,7 +54,8 @@ using BenchmarkTools
 # Create a reactive NPI: reduce transmission when hospitalizations exceed 20,000
 effect = Daedalus.DaedalusStructs.ParamEffect(
     :beta,
-    x -> x .* 0.3;  # 70% reduction
+    x -> x .* 0.3,      # 70% reduction
+    x -> x ./ 0.3;      # reset: divide by 0.3
     on = ("H", 20000.0),
     off = ("Rt", 1.0)
 )

--- a/docs/src/ensemble.md
+++ b/docs/src/ensemble.md
@@ -94,12 +94,14 @@ Non-pharmaceutical interventions (NPIs) are applied consistently across all R0 v
 using Daedalus
 
 # Define a reactive NPI: reduce transmission by 50% when hospitalizations exceed 10,000
+trigger_on = Daedalus.DaedalusStructs.ReactiveTrigger(10000.0, "H")
+trigger_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
 effect = Daedalus.DaedalusStructs.ParamEffect(
     :beta,
     x -> x .* 0.5,      # 50% reduction
-    x -> x ./ 0.5;      # reset: divide by 0.5
-    on = ("H", 10000.0),
-    off = ("Rt", 1.0)
+    x -> x ./ 0.5,      # reset: divide by 0.5
+    trigger_on,         # Activate when H > 10000
+    trigger_off         # Deactivate when Rt < 1.0
 )
 npi = Daedalus.DaedalusStructs.Npi([effect])
 

--- a/docs/src/ensemble.md
+++ b/docs/src/ensemble.md
@@ -96,7 +96,8 @@ using Daedalus
 # Define a reactive NPI: reduce transmission by 50% when hospitalizations exceed 10,000
 effect = Daedalus.DaedalusStructs.ParamEffect(
     :beta,
-    x -> x .* 0.5;  # 50% reduction
+    x -> x .* 0.5,      # 50% reduction
+    x -> x ./ 0.5;      # reset: divide by 0.5
     on = ("H", 10000.0),
     off = ("Rt", 1.0)
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,7 @@ CurrentModule = Daedalus
 # Daedalus.jl
 
 [![License:MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/version-0.0.8-aquamarine.svg)](https://jameel-institute.github.io/Daedalus.jl/dev/)
+[![Version](https://img.shields.io/badge/version-0.0.9-aquamarine.svg)](https://jameel-institute.github.io/Daedalus.jl/dev/)
 [![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://jameel-institute.github.io/Daedalus.jl/dev/)
 [![Build Status](https://github.com/jameel-institute/Daedalus.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/jameel-institute/Daedalus.jl/actions/workflows/CI.yml?query=branch%3Amain)
@@ -35,7 +35,6 @@ using Plots
 
 # pump up r0 to get peak within 50 days
 infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
-infection.r0 = 5.0
 data = daedalus("Canada", infection, time_end=600.0);
 
 # plot exposed group

--- a/docs/src/musings.md
+++ b/docs/src/musings.md
@@ -1,5 +1,0 @@
-```@meta
-CurrentModule = Daedalus
-```
-
-This page for recording why reactive events are implemented in the way they are, and the way forward for both reactive state-dependent, timed, and mixed event types in _Daedalus.jl_ and ODE models.

--- a/docs/src/npis.md
+++ b/docs/src/npis.md
@@ -1,7 +1,0 @@
-```@meta
-CurrentModule = Daedalus
-```
-
-# Modelling interventions and events
-
-WIP: section to include how events are modelled with focus on NPIs.

--- a/docs/src/state_dep_npis.md
+++ b/docs/src/state_dep_npis.md
@@ -29,13 +29,15 @@ For a compartmental epidemic model this equates to an event that is reactive to 
 using Daedalus
 using Plots
 
-# Create an effect: reduce beta by 20% when hospitalizations exceed 5000
+# Create an effect: reduce beta by 20% when hospitalizations exceed 20000
+trigger_on = Daedalus.DaedalusStructs.ReactiveTrigger(20000.0, "H")
+trigger_off = Daedalus.DaedalusStructs.ReactiveTrigger(10000.0, "H")
 effect = Daedalus.DaedalusStructs.ParamEffect(
     :beta,
-    x -> x .* 0.7,         # reduce by 20%
-    x -> x ./ 0.7;         # reset: divide by 0.8
-    on = ("H", 20000.0),    # Activate when H > 20000
-    off = ("H", 10000.0)      # Deactivate when H < 10000.0
+    x -> x .* 0.8,         # reduce by 20%
+    x -> x ./ 0.8,         # reset: divide by 0.8
+    trigger_on,             # Activate when H > 20000
+    trigger_off             # Deactivate when H < 10000
 )
 
 # Create NPI from the effect
@@ -77,21 +79,25 @@ using Daedalus
 using Plots
 
 # Create multiple effects with different triggers
+trigger_beta_on = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+trigger_beta_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
 effect_beta = Daedalus.DaedalusStructs.ParamEffect(
     :beta,
     x -> x .* 0.8,         # reduce by 20%
-    x -> x ./ 0.8;         # reset: divide by 0.8
-    on = ("H", 5000.0),    # Activate on hospitalizations
-    off = ("Rt", 1.0)
+    x -> x ./ 0.8,         # reset: divide by 0.8
+    trigger_beta_on,        # Activate on hospitalizations
+    trigger_beta_off        # Deactivate when Rt < 1.0
 )
 
 hosp_capacity = 20e3
+trigger_omega_on = Daedalus.DaedalusStructs.ReactiveTrigger(hosp_capacity, "H")
+trigger_omega_off = Daedalus.DaedalusStructs.ReactiveTrigger(hosp_capacity / 2.0, "H")
 effect_omega = Daedalus.DaedalusStructs.ParamEffect(
     :omega,
     x -> x .* 1.2,         # increase by 20%
-    x -> x ./ 1.2;         # reset: divide by 1.2
-    on = ("H", hosp_capacity),
-    off = ("H", hosp_capacity / 2.0)
+    x -> x ./ 1.2,         # reset: divide by 1.2
+    trigger_omega_on,       # Activate at high occupancy
+    trigger_omega_off       # Deactivate at medium occupancy
 )
 
 # Create NPI with both effects

--- a/docs/src/state_dep_npis.md
+++ b/docs/src/state_dep_npis.md
@@ -17,7 +17,13 @@ State-dependent NPIs may be useful when there is clarity on the system state tha
 - How to modify it (transformation function)
 - When to activate and deactivate (independent trigger conditions per effect)
 
-## Basic example: Single parameter with custom trigger
+## Basic example: Single parameter with prevalence trigger
+
+This example shows how to implement an NPI that reduces transmission by 20% once hospital occupancy crosses 20000 beds.
+The NPI is removed once hospital occupancy falls below 10000 beds.
+
+This is the simplest kind of reactive event, as it is conditioned on the state of the system `x`.
+For a compartmental epidemic model this equates to an event that is reactive to prevalence.
 
 ```@example reactive_npi
 using Daedalus
@@ -26,9 +32,10 @@ using Plots
 # Create an effect: reduce beta by 20% when hospitalizations exceed 5000
 effect = Daedalus.DaedalusStructs.ParamEffect(
     :beta,
-    x -> x .* 0.8;
-    on = ("H", 5000.0),    # Activate when H > 5000
-    off = ("Rt", 1.0)      # Deactivate when Rt < 1.0
+    x -> x .* 0.7,         # reduce by 20%
+    x -> x ./ 0.7;         # reset: divide by 0.8
+    on = ("H", 20000.0),    # Activate when H > 20000
+    off = ("H", 10000.0)      # Deactivate when H < 10000.0
 )
 
 # Create NPI from the effect
@@ -72,15 +79,17 @@ using Plots
 # Create multiple effects with different triggers
 effect_beta = Daedalus.DaedalusStructs.ParamEffect(
     :beta,
-    x -> x .* 0.8;
-    on = ("H", 5000.0),     # Activate on hospitalizations
+    x -> x .* 0.8,         # reduce by 20%
+    x -> x ./ 0.8;         # reset: divide by 0.8
+    on = ("H", 5000.0),    # Activate on hospitalizations
     off = ("Rt", 1.0)
 )
 
 hosp_capacity = 20e3
 effect_omega = Daedalus.DaedalusStructs.ParamEffect(
     :omega,
-    x -> x .* 1.2;
+    x -> x .* 1.2,         # increase by 20%
+    x -> x ./ 1.2;         # reset: divide by 1.2
     on = ("H", hosp_capacity),
     off = ("H", hosp_capacity / 2.0)
 )

--- a/docs/src/time_dep_npis.md
+++ b/docs/src/time_dep_npis.md
@@ -5,7 +5,7 @@ CurrentModule = Daedalus
 
 # Time-dependent interventions
 
-`TimedNpi` interventions are responsive only to time, not epidemic state. Use these when intervention timing is fixed (e.g., legislative lockdowns or pre-planned public health campaigns).
+`TimedNpi` interventions are responsive only to time, not epidemic state.
 
 ### Single-Phase Example
 
@@ -14,15 +14,12 @@ using Daedalus
 using Plots
 
 # Simple lockdown: reduce transmission by 70% from day 15 to day 45
-timed_npi = Daedalus.DaedalusStructs.TimedNpi(
-    30.0, # start time (days)
-    90.0, # end time (days)
-    0.3, # coefficient (0.3 = 70% reduction)
-    "lockdown"
+timed_npi = Npi(
+    [TimedEffect(
+        :beta, x -> x .* 0.3, x -> x ./ 0.3,
+        30.0, 90.0
+    )]
 )
-
-# Create infection data
-infection_timed = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
 
 data = daedalus("Australia", "sars-cov-2 delta", npi=timed_npi, time_end=300.0);
 data_default = daedalus("Australia", "sars-cov-2 delta", time_end=300.0);
@@ -33,8 +30,9 @@ exposed_default = Daedalus.Outputs.get_values(data_default, "E", 1)
 times = Daedalus.Outputs.get_times(data)
 
 plot(times, exposed, label="Exposed w/ NPI")
+plot!(times, exposed_default, label = "Exposed w/o NPI")
 xlabel!("Time (days)")
-ylabel!("Exposed count")
+ylabel!("# exposed")
 ```
 
 ### Multi-phased timed-NPI
@@ -46,11 +44,16 @@ using Daedalus
 using Plots
 
 # Define three intervention phases
-timed_npi = Daedalus.DaedalusStructs.TimedNpi(
-    [60.0, 180.0, 300.0],      # start times
-    [120.0, 200.0, 365.0],     # end times
-    [0.3, 0.7, 0.5],           # coefficients (70%, 30%, 50% reduction)
-    "three_phase_lockdown"
+timed_npi = Npi(
+    [TimedEffect(
+        :beta, x -> x .* 0.8, x -> x ./ 0.8, 60.0, 120.0
+    ),
+    TimedEffect(
+        :beta, x -> x .* 0.5, x -> x ./ 0.7, 130.0, 200.0
+    ),
+    TimedEffect(
+        :beta, x -> x .* 0.8, x -> x ./ 0.5, 210.0, 365.0
+    )]
 )
 
 data = daedalus("Australia", "sars-cov-2 delta", npi=timed_npi, time_end=400.0);
@@ -64,6 +67,6 @@ times = Daedalus.Outputs.get_times(data)
 plot(times, exposed, label="Exposed w/ NPI")
 plot!(times, exposed_default, label="Exposed w/o NPI")
 xlabel!("Time (days)")
-ylabel!("Exposed count")
+ylabel!("# exposed")
 title!("Three-Phase Intervention Strategy")
 ```

--- a/docs/src/time_dep_npis.md
+++ b/docs/src/time_dep_npis.md
@@ -5,7 +5,7 @@ CurrentModule = Daedalus
 
 # Time-dependent interventions
 
-`TimedNpi` interventions are responsive only to time, not epidemic state.
+Time-based interventions are triggered at specific simulation times, not by epidemic state.
 
 ### Single-Phase Example
 
@@ -13,13 +13,14 @@ CurrentModule = Daedalus
 using Daedalus
 using Plots
 
-# Simple lockdown: reduce transmission by 70% from day 15 to day 45
-timed_npi = Npi(
-    [TimedEffect(
-        :beta, x -> x .* 0.3, x -> x ./ 0.3,
-        30.0, 90.0
-    )]
+# Simple lockdown: reduce transmission by 70% from day 30 to day 90
+trigger_on = Daedalus.DaedalusStructs.TimeTrigger(30.0)
+trigger_off = Daedalus.DaedalusStructs.TimeTrigger(90.0)
+effect = Daedalus.DaedalusStructs.ParamEffect(
+    :beta, x -> x .* 0.3, x -> x ./ 0.3,
+    trigger_on, trigger_off
 )
+timed_npi = Daedalus.DaedalusStructs.Npi([effect])
 
 data = daedalus("Australia", "sars-cov-2 delta", npi=timed_npi, time_end=300.0);
 data_default = daedalus("Australia", "sars-cov-2 delta", time_end=300.0);
@@ -35,7 +36,7 @@ xlabel!("Time (days)")
 ylabel!("# exposed")
 ```
 
-### Multi-phased timed-NPI
+### Multi-phased time-based NPI
 
 Chain multiple intervention phases (e.g., lockdown → relaxation → second wave control):
 
@@ -43,18 +44,25 @@ Chain multiple intervention phases (e.g., lockdown → relaxation → second wav
 using Daedalus
 using Plots
 
-# Define three intervention phases
-timed_npi = Npi(
-    [TimedEffect(
-        :beta, x -> x .* 0.8, x -> x ./ 0.8, 60.0, 120.0
+# Define three intervention phases with different time windows
+effects = [
+    Daedalus.DaedalusStructs.ParamEffect(
+        :beta, x -> x .* 0.3, x -> x ./ 0.3,
+        Daedalus.DaedalusStructs.TimeTrigger(60.0),
+        Daedalus.DaedalusStructs.TimeTrigger(120.0)
     ),
-    TimedEffect(
-        :beta, x -> x .* 0.5, x -> x ./ 0.7, 130.0, 200.0
+    Daedalus.DaedalusStructs.ParamEffect(
+        :beta, x -> x .* 0.8, x -> x ./ 0.8,
+        Daedalus.DaedalusStructs.TimeTrigger(130.0),
+        Daedalus.DaedalusStructs.TimeTrigger(200.0)
     ),
-    TimedEffect(
-        :beta, x -> x .* 0.8, x -> x ./ 0.5, 210.0, 365.0
-    )]
-)
+    Daedalus.DaedalusStructs.ParamEffect(
+        :beta, x -> x .* 0.5, x -> x ./ 0.5,
+        Daedalus.DaedalusStructs.TimeTrigger(210.0),
+        Daedalus.DaedalusStructs.TimeTrigger(365.0)
+    )
+]
+timed_npi = Daedalus.DaedalusStructs.Npi(effects)
 
 data = daedalus("Australia", "sars-cov-2 delta", npi=timed_npi, time_end=400.0);
 data_default = daedalus("Australia", "sars-cov-2 delta", time_end=400.0);

--- a/src/Daedalus.jl
+++ b/src/Daedalus.jl
@@ -12,4 +12,6 @@ include("Model.jl")
 include("Ensemble.jl")
 include("Outputs.jl")
 
+export Npi, ReactiveEffect, TimedEffect
+
 end

--- a/src/Daedalus.jl
+++ b/src/Daedalus.jl
@@ -12,6 +12,6 @@ include("Model.jl")
 include("Ensemble.jl")
 include("Outputs.jl")
 
-export Npi, ReactiveEffect, TimedEffect
+export Npi, ParamEffect, ReactiveTrigger, TimeTrigger, get_values, get_time
 
 end

--- a/src/DaedalusStructs.jl
+++ b/src/DaedalusStructs.jl
@@ -44,6 +44,20 @@ abstract type Trigger end
 
 abstract type Effect end
 
+"""
+    ReactiveTrigger
+
+A trigger based on epidemic state (e.g., hospitalization count, Rt).
+
+# Fields
+- `name::String`: Compartment name (e.g., "H", "Rt")
+- `value::Float64`: Threshold value for triggering
+
+# Constructor
+```julia
+ReactiveTrigger(value::Float64, name::String)
+```
+"""
 struct ReactiveTrigger <: Trigger
     name::String
     value::Float64
@@ -53,6 +67,20 @@ struct ReactiveTrigger <: Trigger
     end
 end
 
+"""
+    TimeTrigger
+
+A trigger based on simulation time.
+
+# Fields
+- `name::String`: Always "time"
+- `value::Float64`: Time point (days) for triggering
+
+# Constructor
+```julia
+TimeTrigger(value::Float64, name::String = "time")
+```
+"""
 struct TimeTrigger <: Trigger
     name::String
     value::Float64
@@ -64,6 +92,30 @@ end
 
 """
     ParamEffect
+
+A parameter modification triggered by state or time conditions.
+
+# Fields
+- `target::Symbol`: Parameter to modify (e.g., `:beta`, `:omega`)
+- `func::Function`: Applied when activated
+- `reset_func::Function`: Applied when deactivated
+- `trigger_on::Trigger`: Activation condition (`ReactiveTrigger` or `TimeTrigger`)
+- `trigger_off::Trigger`: Deactivation condition
+- `saved_values::SavedValues`: Internal state tracking
+- `ison::Bool`: Current activation state
+
+# Constructor
+```julia
+ParamEffect(target::Symbol, func::Function, reset_func::Function,
+            trigger_on::Trigger, trigger_off::Trigger)
+```
+
+# Example
+```julia
+trigger_on = ReactiveTrigger(5000.0, "H")
+trigger_off = ReactiveTrigger(1.0, "Rt")
+effect = ParamEffect(:beta, x -> x .* 0.4, x -> x ./ 0.4, trigger_on, trigger_off)
+```
 """
 mutable struct ParamEffect <: Effect
     target::Symbol
@@ -74,7 +126,6 @@ mutable struct ParamEffect <: Effect
     saved_values::SavedValues
     ison::Bool
 
-    # Full constructor with StateData objects
     function ParamEffect(target::Symbol, func::Function,
             reset_func::Function,
             trigger_on::Trigger, trigger_off::Trigger)
@@ -86,22 +137,24 @@ end
 """
     Npi
 
-A mutable struct to specify non-pharmaceutical interventions (NPIs). It is a unified container
-of parameter effects (both reactive and timed), each specifying how to modify an ODE parameter
-and when to activate/deactivate.
+A container for parameter modifications (effects), each with trigger conditions.
 
 # Fields
-- `effects::Vector{ParamEffect}`: Parameter modifications to apply.
+- `effects::Vector{Effect}`: Vector of parameter modifications to apply
 
-# Constructors
-
-## Direct container constructor
+# Constructor
 ```julia
-Npi(effects::AbstractVector{<:ParamEffect})
+Npi(effects::AbstractVector{<:Effect})
 ```
 
-# Examples
-
+# Example
+```julia
+trigger_on = ReactiveTrigger(5000.0, "H")
+trigger_off = ReactiveTrigger(1.0, "Rt")
+effect = ParamEffect(
+    :beta, x -> x .* 0.4, x -> x ./ 0.4, trigger_on, trigger_off)
+npi = Npi([effect])
+```
 """
 mutable struct Npi <: Event
     effects::Vector{Effect}

--- a/src/DaedalusStructs.jl
+++ b/src/DaedalusStructs.jl
@@ -5,8 +5,8 @@ using ..Constants
 
 using DiffEqCallbacks
 
-export Params, Npi, TimedNpi, ParamEffect, StateData, CtStateData, DsStateData,
-       get_indices, n_phases, total_duration
+export Params, Npi, ReactiveEffect, TimedEffect, StateData, CtStateData, DsStateData,
+       get_indices
 
 """
     Params
@@ -43,7 +43,7 @@ abstract type Event end
 
 abstract type StateData end
 
-abstract type Effect end
+abstract type ParamEffect end
 
 struct CtStateData <: StateData
     name::String
@@ -66,10 +66,11 @@ struct DsStateData <: StateData
 end
 
 """
-    ParamEffect
+    ReactiveEffect
 
-A mutable struct specifying how an NPI modifies a single ODE parameter, including
-independent trigger conditions for activation and deactivation.
+A mutable struct specifying how an NPI modifies a single ODE parameter in response to
+epidemic state (reactive/state-dependent). Each effect has independent trigger conditions
+for activation and deactivation.
 
 # Fields
 - `target::Symbol`: The parameter to modify (e.g., `:beta`, `:omega`)
@@ -86,24 +87,24 @@ independent trigger conditions for activation and deactivation.
 
 ## Full constructor (with StateData objects)
 ```julia
-ParamEffect(target::Symbol, func::Function, comp_on::StateData, comp_off::StateData)
+ReactiveEffect(target::Symbol, func::Function, comp_on::StateData, comp_off::StateData)
 ```
 
 ## Keyword convenience constructor
 ```julia
-ParamEffect(target::Symbol, func::Function, reset_func::Function; on::Tuple{String, Float64}, off::Tuple{String, Float64})
+ReactiveEffect(target::Symbol, func::Function, reset_func::Function; on::Tuple{String, Float64}, off::Tuple{String, Float64})
 ```
 
 Example:
 ```julia
 # Reduce beta by 60% when H > 5000, restore when Rt < 1.0
-ParamEffect(:beta, x -> x .* 0.4, x -> x ./ 0.4; on=("H", 5000.0), off=("Rt", 1.0))
+ReactiveEffect(:beta, x -> x .* 0.4, x -> x ./ 0.4; on=("H", 5000.0), off=("Rt", 1.0))
 
 # Reduce gamma_Ia by 20% when D > 100, restore when I < 8000
-ParamEffect(:gamma_Ia, x -> x .* 0.8, x -> x ./ 0.8; on=("D", 100.0), off=("I", 8000.0))
+ReactiveEffect(:gamma_Ia, x -> x .* 0.8, x -> x ./ 0.8; on=("D", 100.0), off=("I", 8000.0))
 ```
 """
-mutable struct ParamEffect <: Effect
+mutable struct ReactiveEffect <: ParamEffect
     target::Symbol
     func::Function
     reset_func::Function
@@ -113,7 +114,7 @@ mutable struct ParamEffect <: Effect
     ison::Bool
 
     # Full constructor with StateData objects
-    function ParamEffect(target::Symbol, func::Function,
+    function ReactiveEffect(target::Symbol, func::Function,
             reset_func::Function,
             comp_on::StateData, comp_off::StateData)
         sv = SavedValues(Float64, Tuple{Float64, Float64})
@@ -121,11 +122,11 @@ mutable struct ParamEffect <: Effect
     end
 end
 
-# Keyword convenience constructor for ParamEffect
-function ParamEffect(target::Symbol, func::Function, reset_func::Function;
+# Keyword convenience constructor for ReactiveEffect
+function ReactiveEffect(target::Symbol, func::Function, reset_func::Function;
         on::Tuple{String, Float64},
         off::Tuple{String, Float64})
-    ParamEffect(target, func, reset_func, CtStateData(on...), DsStateData(off...))
+    ReactiveEffect(target, func, reset_func, CtStateData(on...), DsStateData(off...))
 end
 
 """
@@ -139,207 +140,93 @@ function get_indices(x::StateData)
 end
 
 """
-    Npi
+    TimedEffect
 
-A mutable struct to specify a reactive (state-dependent) NPI. It is a container of
-`ParamEffect`s, each with independent trigger conditions for activation and deactivation.
+A mutable struct specifying how an NPI modifies a single ODE parameter at
+specified time points (time-limited / timed intervention).
 
 # Fields
-- `effects::Vector{ParamEffect}`: Parameter modifications to apply, each with its own trigger
+- `target::Symbol`: The parameter to modify (e.g., `:beta`, `:omega`)
+- `func::Function`: A function mapping the original parameter value to the modified value
+- `reset_func::Function`: A function mapping the modified parameter value back to the original value
+- `start_time::Float64`: Time (days) at which to activate the effect
+- `end_time::Float64`: Time (days) at which to deactivate the effect
+
+# Constructor
+```julia
+TimedEffect(target::Symbol, func::Function, reset_func::Function, start_time::Float64, end_time::Float64)
+```
+
+# Example
+```julia
+# Reduce beta by 30% from day 10 to day 40
+TimedEffect(:beta, x -> x .* 0.7, x -> x ./ 0.7, 10.0, 40.0)
+
+# Increase omega by 20% from day 15 to day 50
+TimedEffect(:omega, x -> x .* 1.2, x -> x ./ 1.2, 15.0, 50.0)
+```
+"""
+mutable struct TimedEffect <: ParamEffect
+    target::Symbol
+    func::Function
+    reset_func::Function
+    start_time::Float64
+    end_time::Float64
+
+    function TimedEffect(target::Symbol, func::Function, reset_func::Function,
+            start_time::Float64, end_time::Float64)
+        return new(target, func, reset_func, start_time, end_time)
+    end
+end
+
+"""
+    Npi
+
+A mutable struct to specify non-pharmaceutical interventions (NPIs). It is a unified container
+of parameter effects (both reactive and timed), each specifying how to modify an ODE parameter
+and when to activate/deactivate.
+
+# Fields
+- `effects::Vector{ParamEffect}`: Parameter modifications to apply. May contain both
+  `ReactiveEffect` (state-dependent) and `TimedEffect` (time-limited) objects.
 
 # Constructors
 
 ## Direct container constructor
 ```julia
-Npi(effects::Vector{ParamEffect})
+Npi(effects::AbstractVector{<:ParamEffect})
 ```
 
 # Examples
 
 ```julia
+# Reactive effects: respond to epidemic state
 npi = Npi([
-    ParamEffect(:beta,     x -> x .* 0.4, x -> x ./ 0.4; on=("H", 5000.0), off=("Rt", 1.0)),
-    ParamEffect(:gamma_Ia, x -> x .* 0.8, x -> x ./ 0.8; on=("D",  100.0), off=("Rt", 1.0)),
-    ParamEffect(:gamma_Is, x -> x .* 0.8, x -> x ./ 0.8; on=("I", 8000.0), off=("H", 3000.0)),
+    ReactiveEffect(:beta, x -> x .* 0.4, x -> x ./ 0.4; on=("H", 5000.0), off=("Rt", 1.0)),
+    ReactiveEffect(:gamma_Ia, x -> x .* 0.8, x -> x ./ 0.8; on=("D",  100.0), off=("Rt", 1.0)),
+])
+
+# Timed effects: activate at specified times
+npi = Npi([
+    TimedEffect(:beta, x -> x .* 0.7, x -> x ./ 0.7, 10.0, 40.0),
+    TimedEffect(:omega, x -> x .* 1.2, x -> x ./ 1.2, 15.0, 50.0),
+])
+
+# Mixed: both reactive and timed effects
+npi = Npi([
+    ReactiveEffect(:beta, x -> x .* 0.6, x -> x ./ 0.6; on=("H", 10000.0), off=("Rt", 1.0)),
+    TimedEffect(:omega, x -> x .* 1.1, x -> x ./ 1.1, 20.0, 60.0),
 ])
 ```
 """
 mutable struct Npi <: Event
     effects::Vector{ParamEffect}
 
-    # Direct constructor (vector of ParamEffect)
-    function Npi(effects::Vector{ParamEffect})
-        return new(effects)
+    # Direct constructor (accepts any vector of ParamEffect subtypes)
+    function Npi(effects::AbstractVector{<:ParamEffect})
+        return new(Vector{ParamEffect}(effects))
     end
 end
 
-"""
-    TimedNpi
-
-A struct to specify time-limited non-pharmaceutical interventions (NPIs).
-Unlike `Npi`, these interventions are purely time-based and do not respond
-to epidemic state. Supports multiple intervention phases with different
-intensity levels.
-
-# Fields
-- `start_times::Vector{Float64}`: Start times for each intervention phase (days)
-- `end_times::Vector{Float64}`: End times for each intervention phase (days)
-- `coefs::Vector{Float64}`: Transmission reduction coefficient for each phase.
-  Values should be in [0, 1] where 1 = no intervention, 0 = complete transmission block.
-- `identifier::String`: Name or description of the intervention strategy
-
-# Constraints
-- All vectors must have the same length
-- `end_times[i] >= start_times[i]` for all i
-- Time intervals must be non-overlapping
-- Times must be sorted in ascending order
-- Coefficients must be in [0, 1]
-
-# Example
-```julia
-# Three-phase intervention: moderate → strict → relaxed
-timed_npi = TimedNpi(
-    [10.0, 30.0, 60.0],  # start times
-    [25.0, 55.0, 90.0],  # end times
-    [0.7, 0.3, 0.5],     # coefs (0.7 = 30% reduction, 0.3 = 70% reduction)
-    "three_phase_lockdown"
-)
-```
-"""
-struct TimedNpi <: Event
-    start_times::Vector{Float64}
-    end_times::Vector{Float64}
-    coefs::Vector{Float64}
-    identifier::String
-
-    function TimedNpi(
-            start_times::Vector{Float64},
-            end_times::Vector{Float64},
-            coefs::Vector{Float64},
-            identifier::String = "custom_timed"
-    )
-        # Validate vector lengths match
-        n_phases = length(start_times)
-        if length(end_times) != n_phases
-            throw(ArgumentError(
-                "end_times must have same length as start_times " *
-                "(got $(length(end_times)), expected $n_phases)"
-            ))
-        end
-        if length(coefs) != n_phases
-            throw(ArgumentError(
-                "coefs must have same length as start_times " *
-                "(got $(length(coefs)), expected $n_phases)"
-            ))
-        end
-
-        # Validate times are non-negative
-        if !all(start_times .>= 0.0)
-            throw(ArgumentError("start_times must be non-negative"))
-        end
-        if !all(end_times .>= 0.0)
-            throw(ArgumentError("end_times must be non-negative"))
-        end
-
-        # Validate end_times >= start_times
-        for i in 1:n_phases
-            if end_times[i] < start_times[i]
-                throw(ArgumentError(
-                    "end_times[$i] ($(end_times[i])) must be >= " *
-                    "start_times[$i] ($(start_times[i]))"
-                ))
-            end
-        end
-
-        # Validate times are sorted
-        if !issorted(start_times)
-            throw(ArgumentError("start_times must be in ascending order"))
-        end
-        if !issorted(end_times)
-            throw(ArgumentError("end_times must be in ascending order"))
-        end
-
-        # Validate non-overlapping intervals
-        for i in 1:(n_phases - 1)
-            if end_times[i] >= start_times[i + 1]
-                throw(ArgumentError(
-                    "Overlapping intervals detected: phase $i ends at " *
-                    "$(end_times[i]) but phase $(i+1) starts at " *
-                    "$(start_times[i+1])"
-                ))
-            end
-        end
-
-        # Validate coefficients in [0, 1]
-        if !all(0.0 .<= coefs .<= 1.0)
-            throw(ArgumentError("coefs must be in range [0.0, 1.0]"))
-        end
-
-        new(start_times, end_times, coefs, identifier)
-    end
-
-    # Convenience constructor for single-phase intervention
-    function TimedNpi(
-            start_time::Float64,
-            end_time::Float64,
-            coef::Float64,
-            identifier::String = "single_phase"
-    )
-        TimedNpi([start_time], [end_time], [coef], identifier)
-    end
-end
-
-"""
-    n_phases(npi::TimedNpi)
-
-Return the number of intervention phases in a TimedNpi.
-
-# Example
-```julia
-npi = TimedNpi([10.0, 30.0], [20.0, 40.0], [0.7, 0.5])
-n_phases(npi)  # Returns: 2
-```
-"""
-n_phases(npi::TimedNpi) = length(npi.start_times)
-
-"""
-    total_duration(npi::TimedNpi)
-
-Calculate the total duration of all intervention phases combined (not including
-gaps between phases).
-
-# Returns
-- Total days of active intervention
-
-# Example
-```julia
-npi = TimedNpi([10.0, 30.0], [20.0, 40.0], [0.7, 0.5])
-# Phase 1: 10 days (10-20), Phase 2: 10 days (30-40)
-total_duration(npi)  # Returns: 20.0
-```
-"""
-function total_duration(npi::TimedNpi)
-    return sum(npi.end_times .- npi.start_times)
-end
-
-# Base.show method for pretty printing
-function Base.show(io::IO, npi::TimedNpi)
-    n = n_phases(npi)
-    total_dur = total_duration(npi)
-
-    println(io, "TimedNpi: $(npi.identifier)")
-    println(io, "  Number of phases: $n")
-    println(io, "  Total duration: $(round(total_dur, digits=1)) days")
-
-    for i in 1:n
-        duration = npi.end_times[i] - npi.start_times[i]
-        reduction = round((1.0 - npi.coefs[i]) * 100, digits = 1)
-        println(
-            io,
-            "  Phase $i: days $(npi.start_times[i])-$(npi.end_times[i]) " *
-            "($(round(duration, digits=1))d), $(reduction)% reduction"
-        )
-    end
-end
 
 end

--- a/src/DaedalusStructs.jl
+++ b/src/DaedalusStructs.jl
@@ -5,8 +5,7 @@ using ..Constants
 
 using DiffEqCallbacks
 
-export Params, Npi, ReactiveEffect, TimedEffect, StateData, CtStateData, DsStateData,
-       get_indices
+export Params, Npi, Effect, ParamEffect, Trigger, ReactiveTrigger, TimeTrigger
 
 """
     Params
@@ -49,7 +48,7 @@ struct ReactiveTrigger <: Trigger
     name::String
     value::Float64
 
-    function ReactiveTrigger(name, value)
+    function ReactiveTrigger(value, name)
         return new(name, value)
     end
 end
@@ -58,49 +57,13 @@ struct TimeTrigger <: Trigger
     name::String
     value::Float64
 
-    function TimeTrigger(name = "time", value)
+    function TimeTrigger(value, name = "time")
         return new(name, value)
     end
 end
 
 """
-    ReactiveEffect
-
-A mutable struct specifying how an NPI modifies a single ODE parameter in response to
-epidemic state (reactive/state-dependent). Each effect has independent trigger conditions
-for activation and deactivation.
-
-# Fields
-- `target::Symbol`: The parameter to modify (e.g., `:beta`, `:omega`)
-- `func::Function`: A function mapping the original parameter value to the modified value
-- `reset_func::Function`: A function mapping the modified parameter value to the
-    original value. This is needed when multiple effects overlap, so as to be
-    able to return `target` to its pre-modification value.
-- `trigger_on::StateData`: Trigger condition to activate this effect
-- `trigger_off::StateData`: Trigger condition to deactivate this effect
-- `saved_values::SavedValues`: Historical state values for tracking this effect's triggers
-- `is_on::Bool`: Current activation status for this effect
-
-# Constructors
-
-## Full constructor (with StateData objects)
-```julia
-ReactiveEffect(target::Symbol, func::Function, trigger_on::StateData, trigger_off::StateData)
-```
-
-## Keyword convenience constructor
-```julia
-ReactiveEffect(target::Symbol, func::Function, reset_func::Function; on::Tuple{String, Float64}, off::Tuple{String, Float64})
-```
-
-Example:
-```julia
-# Reduce beta by 60% when H > 5000, restore when Rt < 1.0
-ReactiveEffect(:beta, x -> x .* 0.4, x -> x ./ 0.4; on=("H", 5000.0), off=("Rt", 1.0))
-
-# Reduce gamma_Ia by 20% when D > 100, restore when I < 8000
-ReactiveEffect(:gamma_Ia, x -> x .* 0.8, x -> x ./ 0.8; on=("D", 100.0), off=("I", 8000.0))
-```
+    ParamEffect
 """
 mutable struct ParamEffect <: Effect
     target::Symbol
@@ -112,71 +75,13 @@ mutable struct ParamEffect <: Effect
     ison::Bool
 
     # Full constructor with StateData objects
-    function ReactiveEffect(target::Symbol, func::Function,
+    function ParamEffect(target::Symbol, func::Function,
             reset_func::Function,
-            trigger_on::StateData, trigger_off::StateData)
+            trigger_on::Trigger, trigger_off::Trigger)
         sv = SavedValues(Float64, Tuple{Float64, Float64})
         return new(target, func, reset_func, trigger_on, trigger_off, sv, false)
     end
 end
-
-# Keyword convenience constructor for ReactiveEffect
-function ReactiveEffect(target::Symbol, func::Function, reset_func::Function;
-        on::Tuple{String, Float64},
-        off::Tuple{String, Float64})
-    ReactiveEffect(target, func, reset_func,
-        ReactiveTrigger(on...), ReactiveTrigger(off...))
-end
-
-"""
-    get_indices(x::StateData)
-
-Get state vector indices for the compartment in a StateData struct.
-Delegates to `Constants.get_indices()`.
-"""
-function get_indices(x::StateData)
-    return Constants.get_indices(x.name)
-end
-
-# """
-#     TimedEffect
-
-# A mutable struct specifying how an NPI modifies a single ODE parameter at
-# specified time points (time-limited / timed intervention).
-
-# # Fields
-# - `target::Symbol`: The parameter to modify (e.g., `:beta`, `:omega`)
-# - `func::Function`: A function mapping the original parameter value to the modified value
-# - `reset_func::Function`: A function mapping the modified parameter value back to the original value
-# - `start_time::Float64`: Time (days) at which to activate the effect
-# - `end_time::Float64`: Time (days) at which to deactivate the effect
-
-# # Constructor
-# ```julia
-# TimedEffect(target::Symbol, func::Function, reset_func::Function, start_time::Float64, end_time::Float64)
-# ```
-
-# # Example
-# ```julia
-# # Reduce beta by 30% from day 10 to day 40
-# TimedEffect(:beta, x -> x .* 0.7, x -> x ./ 0.7, 10.0, 40.0)
-
-# # Increase omega by 20% from day 15 to day 50
-# TimedEffect(:omega, x -> x .* 1.2, x -> x ./ 1.2, 15.0, 50.0)
-# ```
-# """
-# mutable struct TimedEffect <: ParamEffect
-#     target::Symbol
-#     func::Function
-#     reset_func::Function
-#     start_time::Float64
-#     end_time::Float64
-
-#     function TimedEffect(target::Symbol, func::Function, reset_func::Function,
-#             start_time::Float64, end_time::Float64)
-#         return new(target, func, reset_func, start_time, end_time)
-#     end
-# end
 
 """
     Npi
@@ -186,8 +91,7 @@ of parameter effects (both reactive and timed), each specifying how to modify an
 and when to activate/deactivate.
 
 # Fields
-- `effects::Vector{ParamEffect}`: Parameter modifications to apply. May contain both
-  `ReactiveEffect` (state-dependent) and `TimedEffect` (time-limited) objects.
+- `effects::Vector{ParamEffect}`: Parameter modifications to apply.
 
 # Constructors
 
@@ -198,25 +102,6 @@ Npi(effects::AbstractVector{<:ParamEffect})
 
 # Examples
 
-```julia
-# Reactive effects: respond to epidemic state
-npi = Npi([
-    ReactiveEffect(:beta, x -> x .* 0.4, x -> x ./ 0.4; on=("H", 5000.0), off=("Rt", 1.0)),
-    ReactiveEffect(:gamma_Ia, x -> x .* 0.8, x -> x ./ 0.8; on=("D",  100.0), off=("Rt", 1.0)),
-])
-
-# Timed effects: activate at specified times
-npi = Npi([
-    TimedEffect(:beta, x -> x .* 0.7, x -> x ./ 0.7, 10.0, 40.0),
-    TimedEffect(:omega, x -> x .* 1.2, x -> x ./ 1.2, 15.0, 50.0),
-])
-
-# Mixed: both reactive and timed effects
-npi = Npi([
-    ReactiveEffect(:beta, x -> x .* 0.6, x -> x ./ 0.6; on=("H", 10000.0), off=("Rt", 1.0)),
-    TimedEffect(:omega, x -> x .* 1.1, x -> x ./ 1.1, 20.0, 60.0),
-])
-```
 """
 mutable struct Npi <: Event
     effects::Vector{Effect}

--- a/src/DaedalusStructs.jl
+++ b/src/DaedalusStructs.jl
@@ -41,27 +41,25 @@ end
 
 abstract type Event end
 
-abstract type StateData end
+abstract type Trigger end
 
-abstract type ParamEffect end
+abstract type Effect end
 
-struct CtStateData <: StateData
+struct ReactiveTrigger <: Trigger
     name::String
     value::Float64
-    time_type::String
 
-    function CtStateData(name, value)
-        return new(name, value, "continuous")
+    function ReactiveTrigger(name, value)
+        return new(name, value)
     end
 end
 
-struct DsStateData <: StateData
+struct TimeTrigger <: Trigger
     name::String
     value::Float64
-    time_type::String
 
-    function DsStateData(name, value)
-        return new(name, value, "discrete")
+    function TimeTrigger(name = "time", value)
+        return new(name, value)
     end
 end
 
@@ -78,8 +76,8 @@ for activation and deactivation.
 - `reset_func::Function`: A function mapping the modified parameter value to the
     original value. This is needed when multiple effects overlap, so as to be
     able to return `target` to its pre-modification value.
-- `comp_on::StateData`: Trigger condition to activate this effect
-- `comp_off::StateData`: Trigger condition to deactivate this effect
+- `trigger_on::StateData`: Trigger condition to activate this effect
+- `trigger_off::StateData`: Trigger condition to deactivate this effect
 - `saved_values::SavedValues`: Historical state values for tracking this effect's triggers
 - `is_on::Bool`: Current activation status for this effect
 
@@ -87,7 +85,7 @@ for activation and deactivation.
 
 ## Full constructor (with StateData objects)
 ```julia
-ReactiveEffect(target::Symbol, func::Function, comp_on::StateData, comp_off::StateData)
+ReactiveEffect(target::Symbol, func::Function, trigger_on::StateData, trigger_off::StateData)
 ```
 
 ## Keyword convenience constructor
@@ -104,21 +102,21 @@ ReactiveEffect(:beta, x -> x .* 0.4, x -> x ./ 0.4; on=("H", 5000.0), off=("Rt",
 ReactiveEffect(:gamma_Ia, x -> x .* 0.8, x -> x ./ 0.8; on=("D", 100.0), off=("I", 8000.0))
 ```
 """
-mutable struct ReactiveEffect <: ParamEffect
+mutable struct ParamEffect <: Effect
     target::Symbol
     func::Function
     reset_func::Function
-    comp_on::StateData
-    comp_off::StateData
+    trigger_on::Trigger
+    trigger_off::Trigger
     saved_values::SavedValues
     ison::Bool
 
     # Full constructor with StateData objects
     function ReactiveEffect(target::Symbol, func::Function,
             reset_func::Function,
-            comp_on::StateData, comp_off::StateData)
+            trigger_on::StateData, trigger_off::StateData)
         sv = SavedValues(Float64, Tuple{Float64, Float64})
-        return new(target, func, reset_func, comp_on, comp_off, sv, false)
+        return new(target, func, reset_func, trigger_on, trigger_off, sv, false)
     end
 end
 
@@ -126,7 +124,8 @@ end
 function ReactiveEffect(target::Symbol, func::Function, reset_func::Function;
         on::Tuple{String, Float64},
         off::Tuple{String, Float64})
-    ReactiveEffect(target, func, reset_func, CtStateData(on...), DsStateData(off...))
+    ReactiveEffect(target, func, reset_func,
+        ReactiveTrigger(on...), ReactiveTrigger(off...))
 end
 
 """
@@ -139,45 +138,45 @@ function get_indices(x::StateData)
     return Constants.get_indices(x.name)
 end
 
-"""
-    TimedEffect
+# """
+#     TimedEffect
 
-A mutable struct specifying how an NPI modifies a single ODE parameter at
-specified time points (time-limited / timed intervention).
+# A mutable struct specifying how an NPI modifies a single ODE parameter at
+# specified time points (time-limited / timed intervention).
 
-# Fields
-- `target::Symbol`: The parameter to modify (e.g., `:beta`, `:omega`)
-- `func::Function`: A function mapping the original parameter value to the modified value
-- `reset_func::Function`: A function mapping the modified parameter value back to the original value
-- `start_time::Float64`: Time (days) at which to activate the effect
-- `end_time::Float64`: Time (days) at which to deactivate the effect
+# # Fields
+# - `target::Symbol`: The parameter to modify (e.g., `:beta`, `:omega`)
+# - `func::Function`: A function mapping the original parameter value to the modified value
+# - `reset_func::Function`: A function mapping the modified parameter value back to the original value
+# - `start_time::Float64`: Time (days) at which to activate the effect
+# - `end_time::Float64`: Time (days) at which to deactivate the effect
 
-# Constructor
-```julia
-TimedEffect(target::Symbol, func::Function, reset_func::Function, start_time::Float64, end_time::Float64)
-```
+# # Constructor
+# ```julia
+# TimedEffect(target::Symbol, func::Function, reset_func::Function, start_time::Float64, end_time::Float64)
+# ```
 
-# Example
-```julia
-# Reduce beta by 30% from day 10 to day 40
-TimedEffect(:beta, x -> x .* 0.7, x -> x ./ 0.7, 10.0, 40.0)
+# # Example
+# ```julia
+# # Reduce beta by 30% from day 10 to day 40
+# TimedEffect(:beta, x -> x .* 0.7, x -> x ./ 0.7, 10.0, 40.0)
 
-# Increase omega by 20% from day 15 to day 50
-TimedEffect(:omega, x -> x .* 1.2, x -> x ./ 1.2, 15.0, 50.0)
-```
-"""
-mutable struct TimedEffect <: ParamEffect
-    target::Symbol
-    func::Function
-    reset_func::Function
-    start_time::Float64
-    end_time::Float64
+# # Increase omega by 20% from day 15 to day 50
+# TimedEffect(:omega, x -> x .* 1.2, x -> x ./ 1.2, 15.0, 50.0)
+# ```
+# """
+# mutable struct TimedEffect <: ParamEffect
+#     target::Symbol
+#     func::Function
+#     reset_func::Function
+#     start_time::Float64
+#     end_time::Float64
 
-    function TimedEffect(target::Symbol, func::Function, reset_func::Function,
-            start_time::Float64, end_time::Float64)
-        return new(target, func, reset_func, start_time, end_time)
-    end
-end
+#     function TimedEffect(target::Symbol, func::Function, reset_func::Function,
+#             start_time::Float64, end_time::Float64)
+#         return new(target, func, reset_func, start_time, end_time)
+#     end
+# end
 
 """
     Npi
@@ -220,13 +219,11 @@ npi = Npi([
 ```
 """
 mutable struct Npi <: Event
-    effects::Vector{ParamEffect}
+    effects::Vector{Effect}
 
-    # Direct constructor (accepts any vector of ParamEffect subtypes)
-    function Npi(effects::AbstractVector{<:ParamEffect})
-        return new(Vector{ParamEffect}(effects))
+    function Npi(effects::Vector{<:Effect})
+        return new(Vector{Effect}(effects))
     end
 end
-
 
 end

--- a/src/DaedalusStructs.jl
+++ b/src/DaedalusStructs.jl
@@ -6,7 +6,7 @@ using ..Constants
 using DiffEqCallbacks
 
 export Params, Npi, TimedNpi, ParamEffect, StateData, CtStateData, DsStateData,
-       get_indices, get_comp_threshold, n_phases, total_duration
+       get_indices, n_phases, total_duration
 
 """
     Params
@@ -43,6 +43,8 @@ abstract type Event end
 
 abstract type StateData end
 
+abstract type Effect end
+
 struct CtStateData <: StateData
     name::String
     value::Float64
@@ -70,8 +72,11 @@ A mutable struct specifying how an NPI modifies a single ODE parameter, includin
 independent trigger conditions for activation and deactivation.
 
 # Fields
-- `name::Symbol`: The parameter to modify (e.g., `:beta`, `:omega`)
+- `target::Symbol`: The parameter to modify (e.g., `:beta`, `:omega`)
 - `func::Function`: A function mapping the original parameter value to the modified value
+- `reset_func::Function`: A function mapping the modified parameter value to the
+    original value. This is needed when multiple effects overlap, so as to be
+    able to return `target` to its pre-modification value.
 - `comp_on::StateData`: Trigger condition to activate this effect
 - `comp_off::StateData`: Trigger condition to deactivate this effect
 - `saved_values::SavedValues`: Historical state values for tracking this effect's triggers
@@ -81,44 +86,46 @@ independent trigger conditions for activation and deactivation.
 
 ## Full constructor (with StateData objects)
 ```julia
-ParamEffect(name::Symbol, func::Function, comp_on::StateData, comp_off::StateData)
+ParamEffect(target::Symbol, func::Function, comp_on::StateData, comp_off::StateData)
 ```
 
 ## Keyword convenience constructor
 ```julia
-ParamEffect(name::Symbol, func::Function; on::Tuple{String, Float64}, off::Tuple{String, Float64})
+ParamEffect(target::Symbol, func::Function, reset_func::Function; on::Tuple{String, Float64}, off::Tuple{String, Float64})
 ```
 
 Example:
 ```julia
 # Reduce beta by 60% when H > 5000, restore when Rt < 1.0
-ParamEffect(:beta, x -> x .* 0.4; on=("H", 5000.0), off=("Rt", 1.0))
+ParamEffect(:beta, x -> x .* 0.4, x -> x ./ 0.4; on=("H", 5000.0), off=("Rt", 1.0))
 
 # Reduce gamma_Ia by 20% when D > 100, restore when I < 8000
-ParamEffect(:gamma_Ia, x -> x .* 0.8; on=("D", 100.0), off=("I", 8000.0))
+ParamEffect(:gamma_Ia, x -> x .* 0.8, x -> x ./ 0.8; on=("D", 100.0), off=("I", 8000.0))
 ```
 """
-mutable struct ParamEffect
-    name::Symbol
+mutable struct ParamEffect <: Effect
+    target::Symbol
     func::Function
+    reset_func::Function
     comp_on::StateData
     comp_off::StateData
     saved_values::SavedValues
     ison::Bool
 
     # Full constructor with StateData objects
-    function ParamEffect(name::Symbol, func::Function,
+    function ParamEffect(target::Symbol, func::Function,
+            reset_func::Function,
             comp_on::StateData, comp_off::StateData)
         sv = SavedValues(Float64, Tuple{Float64, Float64})
-        return new(name, func, comp_on, comp_off, sv, false)
+        return new(target, func, reset_func, comp_on, comp_off, sv, false)
     end
 end
 
 # Keyword convenience constructor for ParamEffect
-function ParamEffect(name::Symbol, func::Function;
+function ParamEffect(target::Symbol, func::Function, reset_func::Function;
         on::Tuple{String, Float64},
-        off::Tuple{String, Float64} = ("Rt", 1.0))
-    ParamEffect(name, func, CtStateData(on...), DsStateData(off...))
+        off::Tuple{String, Float64})
+    ParamEffect(target, func, reset_func, CtStateData(on...), DsStateData(off...))
 end
 
 """
@@ -129,31 +136,6 @@ Delegates to `Constants.get_indices()`.
 """
 function get_indices(x::StateData)
     return Constants.get_indices(x.name)
-end
-
-"""
-    get_comp_threshold(x::StateData)::Float64
-
-Get the threshold value from a StateData struct.
-"""
-function get_comp_threshold(x::StateData)::Float64
-    return x.value
-end
-
-"""
-    NpiData
-
-A struct to hold common reactive response parameters.
-"""
-struct NpiData
-    comp_on::StateData
-    comp_off::StateData
-
-    function NpiData(value_comp_on::Float64)
-        comp_on = CtStateData("H", value_comp_on)
-        comp_off = DsStateData("Rt", 1.0)
-        return new(comp_on, comp_off)
-    end
 end
 
 """
@@ -176,9 +158,9 @@ Npi(effects::Vector{ParamEffect})
 
 ```julia
 npi = Npi([
-    ParamEffect(:beta,     x -> x .* 0.4; on=("H", 5000.0), off=("Rt", 1.0)),
-    ParamEffect(:gamma_Ia, x -> x .* 0.8; on=("D",  100.0), off=("Rt", 1.0)),
-    ParamEffect(:gamma_Is, x -> x .* 0.8; on=("I", 8000.0), off=("H", 3000.0)),
+    ParamEffect(:beta,     x -> x .* 0.4, x -> x ./ 0.4; on=("H", 5000.0), off=("Rt", 1.0)),
+    ParamEffect(:gamma_Ia, x -> x .* 0.8, x -> x ./ 0.8; on=("D",  100.0), off=("Rt", 1.0)),
+    ParamEffect(:gamma_Is, x -> x .* 0.8, x -> x ./ 0.8; on=("I", 8000.0), off=("H", 3000.0)),
 ])
 ```
 """
@@ -189,74 +171,6 @@ mutable struct Npi <: Event
     function Npi(effects::Vector{ParamEffect})
         return new(effects)
     end
-end
-
-# Backward-compatible constructors (effects share H/Rt triggers)
-
-function Npi(value_on::Float64, param_names::Vector{Symbol}, func::Function)
-    effects = [ParamEffect(n, func,
-                   CtStateData("H", value_on), DsStateData("Rt", 1.0))
-               for n in param_names]
-    Npi(effects)
-end
-
-function Npi(value_on::Float64, param_name::Symbol, func::Function)
-    Npi(value_on, [param_name], func)
-end
-
-function Npi(value_on::Float64, coefs::NamedTuple)
-    coef = coefs.coef
-    Npi(value_on, [:beta], original -> original .* coef)
-end
-
-"""
-    Npi(threshold::Float64, param_effects::Vector{Pair{Symbol, Function}})
-
-Create an Npi with different transformation functions for each parameter
-(all using default H/Rt triggers).
-
-# Arguments
-- `threshold::Float64`: Hospitalization threshold for activation
-- `param_effects::Vector{Pair{Symbol, Function}}`: Vector of parameter-to-function pairs
-
-# Example
-```julia
-Npi(5000.0, [
-    :beta     => x -> x .* 0.4,
-    :gamma_Ia => x -> x .* 0.8,
-])
-```
-"""
-function Npi(value_on::Float64, param_effects::Vector{<:Pair{Symbol, <:Function}})
-    Npi(value_on,
-        [ParamEffect(p.first, p.second,
-             CtStateData("H", value_on), DsStateData("Rt", 1.0))
-         for p in param_effects])
-end
-
-"""
-    Npi(threshold::Float64, param_effects::Dict{Symbol, Function})
-
-Create an Npi with different transformation functions for each parameter
-(all using default H/Rt triggers). Dict-based variant.
-
-# Arguments
-- `threshold::Float64`: Hospitalization threshold for activation
-- `param_effects::Dict{Symbol, Function}`: Dict mapping parameter names to transformation functions
-
-# Example
-```julia
-Npi(5000.0, Dict(
-    :beta     => x -> x .* 0.4,
-    :gamma_Ia => x -> x .* 0.8,
-))
-```
-"""
-function Npi(value_on::Float64, param_effects::Dict{Symbol, <:Function})
-    Npi(value_on,
-        [ParamEffect(name, func,
-             CtStateData("H", value_on), DsStateData("Rt", 1.0))
-         for (name, func) in param_effects])
 end
 
 """

--- a/src/Ensemble.jl
+++ b/src/Ensemble.jl
@@ -28,7 +28,7 @@ A `Vector{NamedTuple}` where each element contains:
 """
 function daedalus(country::Union{String, DataLoader.CountryData},
         infections::Vector{DataLoader.InfectionData};
-        npi::Union{Npi, TimedNpi, Nothing} = nothing,
+        npi::Union{Npi, Nothing} = nothing,
         log_rt::Bool = true,
         time_end::Float64 = 100.0,
         increment::Float64 = 1.0,
@@ -90,14 +90,6 @@ function daedalus(country::Union{String, DataLoader.CountryData},
             rt_logger = make_rt_logger(savepoints)
             cb_set = CallbackSet(rt_logger)
         end
-    elseif isa(npi, TimedNpi)
-        timed_callbacks = make_timed_npi_callbacks(npi)
-        if log_rt
-            rt_logger = make_rt_logger(savepoints)
-            cb_set = CallbackSet(timed_callbacks, rt_logger)
-        else
-            cb_set = timed_callbacks
-        end
     elseif isa(npi, Npi)
         save_events = make_save_events(npi, savepoints)
         events = make_events(npi, savepoints)
@@ -119,7 +111,7 @@ function daedalus(country::Union{String, DataLoader.CountryData},
         saved_vals = if isnothing(npi)
             nothing
         elseif isa(npi, Npi)
-            [eff.saved_values for eff in npi.effects]
+            [eff.saved_values for eff in npi.effects if isa(eff, ReactiveEffect)]
         else
             nothing
         end

--- a/src/Ensemble.jl
+++ b/src/Ensemble.jl
@@ -111,7 +111,7 @@ function daedalus(country::Union{String, DataLoader.CountryData},
         saved_vals = if isnothing(npi)
             nothing
         elseif isa(npi, Npi)
-            [eff.saved_values for eff in npi.effects if isa(eff, ReactiveEffect)]
+            [eff.saved_values for eff in npi.effects if isa(eff, ParamEffect)]
         else
             nothing
         end

--- a/src/Events.jl
+++ b/src/Events.jl
@@ -15,13 +15,16 @@ export make_events, make_param_changer, make_param_reset,
 """
     make_param_changer(eff::Effect)::Function
 
-Create a callback function that modifies a parameter based on reactive state conditions.
+Create a callback function that modifies a parameter when activated.
+
+Handles both `ReactiveTrigger` (state-dependent) and `TimeTrigger` (time-based)
+activation.
 
 # Arguments
-- `eff::Effect`: A Effect with state-dependent trigger conditions
+- `eff::Effect`: Effect with trigger conditions
 
 # Returns
-A `Function` that takes an `integrator` and modifies the target parameter in-place
+A `Function` that modifies the target parameter in-place
 """
 function make_param_changer(eff::Effect)::Function
     effect! = function () end
@@ -54,13 +57,16 @@ end
 """
     make_param_reset(eff::Effect)::Function
 
-Create a callback function that resets a parameter based on reactive state conditions.
+Create a callback function that resets a parameter when deactivated.
+
+Handles both `ReactiveTrigger` (state-dependent) and `TimeTrigger` (time-based)
+deactivation.
 
 # Arguments
-- `eff::Effect`: A Effect with state-dependent trigger conditions
+- `eff::Effect`: Effect with trigger conditions
 
 # Returns
-A `Function` that takes an `integrator` and resets the target parameter in-place
+A `Function` that resets the target parameter in-place
 """
 function make_param_reset(eff::Effect)::Function
     effect! = function () end
@@ -96,17 +102,19 @@ end
 """
     make_save_events(eff::ParamEffect, savepoints)::Union{SavingCallback, Nothing}
 
-Create a SavingCallback for a single ParamEffect that records trigger compartment values.
+Create a SavingCallback for an effect that records trigger compartment values.
 
-Skips timed effects (returns nothing). For reactive effects, creates a callback that captures
-the values of the on/off trigger compartments at each savepoint.
+Skips effects with all `TimeTrigger` conditions (no state tracking needed).
+For effects with at least one `ReactiveTrigger`, captures trigger compartment
+values at each savepoint.
 
 # Arguments
-- `eff::ParamEffect`: An effect with trigger conditions
+- `eff::ParamEffect`: Effect with trigger conditions
 - `savepoints`: Time points at which to save state values
 
 # Returns
-A `SavingCallback` for reactive effects, or `nothing` for timed effects
+A `SavingCallback` for reactive effects, or `nothing` if both triggers are
+    time-based
 """
 function make_save_events(eff::ParamEffect, savepoints)
     # Skip if both triggers are time-based (this is a timed effect)
@@ -141,18 +149,17 @@ end
 """
     make_save_events(npi::Npi, savepoints)
 
-Create SavingCallbacks that record compartment values at specified timepoints.
+Create SavingCallbacks for all effects that require state tracking.
 
-Returns a vector of `SavingCallback`s, one per reactive effect. Each callback captures the
-values of that effect's on/off trigger compartments at each savepoint. Timed effects
-are skipped (they do not require state-based saving).
+Returns a vector of `SavingCallback`s, one per effect with at least one
+`ReactiveTrigger`. Effects with only `TimeTrigger` conditions are skipped.
 
 # Arguments
-- `npi::Npi`: Npi struct with a vector of effect specifications (both reactive and timed)
+- `npi::Npi`: Npi struct with effects
 - `savepoints`: Time points at which to save state values
 
 # Returns
-A `Vector{SavingCallback}` — one callback per reactive effect, each writing to `eff.saved_values`
+A `Vector{SavingCallback}` — one per effect that has reactive triggers
 """
 function make_save_events(npi::Npi, savepoints)
     cbset = []
@@ -165,6 +172,19 @@ function make_save_events(npi::Npi, savepoints)
     return cbset
 end
 
+"""
+    make_events(eff::ParamEffect, savepoints)::CallbackSet
+
+Create a CallbackSet for an effect's activation and deactivation callbacks.
+
+# Arguments
+- `eff::ParamEffect`: Effect with triggers
+- `savepoints`: Time points for state checking (used if trigger is 
+    `ReactiveTrigger`)
+
+# Returns
+A `CallbackSet` with on/off callbacks
+"""
 function make_events(eff::ParamEffect, savepoints)::CallbackSet
     affect_on! = make_param_changer(eff)
     affect_off! = make_param_reset(eff)
@@ -181,14 +201,14 @@ end
 """
     make_events(npi::Npi, savepoints)::CallbackSet
 
-Create a CallbackSet of event callbacks for an NPI containing both reactive and timed effects.
+Create a CallbackSet of callbacks for all effects in an NPI.
 
 # Arguments
-- `npi::Npi`: Npi struct with a vector of effect specifications
-- `savepoints`: Time points at which to check state for reactive effect triggers
+- `npi::Npi`: Npi struct with effects
+- `savepoints`: Time points for state checking (for reactive triggers)
 
 # Returns
-A `CallbackSet` with all on/off callbacks for all effects
+A `CallbackSet` with all activation/deactivation callbacks
 """
 function make_events(npi::Npi, savepoints)::CallbackSet
     cbset = CallbackSet()

--- a/src/Events.jl
+++ b/src/Events.jl
@@ -13,27 +13,29 @@ export make_events, make_param_changer, make_param_reset,
        make_save_events, make_rt_logger, get_coef
 
 """
-    make_param_changer(eff::ParamEffect)::Function
+    make_param_changer(eff::Effect)::Function
 
 Create a callback function that modifies a parameter based on reactive state conditions.
 
 # Arguments
-- `eff::ParamEffect`: A ParamEffect with state-dependent trigger conditions
+- `eff::Effect`: A Effect with state-dependent trigger conditions
 
 # Returns
 A `Function` that takes an `integrator` and modifies the target parameter in-place
 """
-function make_param_changer(eff::ParamEffect)::Function
-    function effect!(integrator)
-        # special case for time-dependent NPIs
-        if eff.comp_on.name == "time"
+function make_param_changer(eff::Effect)::Function
+    effect! = function () end
+    if isa(eff.trigger_on, TimeTrigger)
+        effect! = function (integrator)
             original = getproperty(integrator.p, eff.target)
             new_val = eff.func(original)
             setproperty!(integrator.p, eff.target, new_val)
-        else
-            # all other triggers
+        end
+        return effect!
+    else
+        effect! = function (integrator)
             if length(eff.saved_values.saveval) > 0
-                value_on = eff.comp_on.value
+                value_on = eff.trigger_on.value
                 u = eff.saved_values.saveval[end][1] # index 1 for comp_on
                 if u > value_on && !eff.ison
                     eff.ison = true
@@ -45,51 +47,37 @@ function make_param_changer(eff::ParamEffect)::Function
                 nothing
             end
         end
-    return effect!
+        return effect!
+    end
 end
 
-# """
-#     make_param_changer(eff::TimedEffect)::Function
-
-# Create a callback function that modifies a parameter for a timed effect.
-
-# # Arguments
-# - `eff::TimedEffect`: A TimedEffect with fixed start/end times
-
-# # Returns
-# A `Function` that takes an `integrator` and modifies the target parameter in-place
-# """
-# function make_param_changer(eff::TimedEffect)::Function
-#     function effect!(integrator)
-#         original = getproperty(integrator.p, eff.target)
-#         new_val = eff.func(original)
-#         setproperty!(integrator.p, eff.target, new_val)
-#     end
-#     return effect!
-# end
-
 """
-    make_param_reset(eff::ReactiveEffect)::Function
+    make_param_reset(eff::Effect)::Function
 
 Create a callback function that resets a parameter based on reactive state conditions.
 
 # Arguments
-- `eff::ReactiveEffect`: A ReactiveEffect with state-dependent trigger conditions
+- `eff::Effect`: A Effect with state-dependent trigger conditions
 
 # Returns
 A `Function` that takes an `integrator` and resets the target parameter in-place
 """
-function make_param_reset(eff::ParamEffect)::Function
-    function effect!(integrator)
-        if eff.comp_off.name == "time"
+function make_param_reset(eff::Effect)::Function
+    effect! = function () end
+    if isa(eff.trigger_on, TimeTrigger)
+        effect! = function (integrator)
             current = getproperty(integrator.p, eff.target)
             reset_val = eff.reset_func(current)
             setproperty!(integrator.p, eff.target, reset_val)
-        else 
+        end
+
+        return effect!
+    else
+        effect! = function (integrator)
             if length(eff.saved_values.saveval) > 0
-                value_off = eff.comp_off.value
-                u = eff.saved_values.saveval[end][2] # index 2 for comp_off
-    
+                value_off = eff.trigger_off.value
+                u = eff.saved_values.saveval[end][2] # index 2 for trigger_off
+
                 if u < value_off && eff.ison
                     eff.ison = false
                     current = getproperty(integrator.p, eff.target)
@@ -100,60 +88,44 @@ function make_param_reset(eff::ParamEffect)::Function
                 nothing
             end
         end
+
+        return effect!
     end
-    return effect!
 end
 
-# """
-#     make_param_reset(eff::TimedEffect)::Function
-
-# Create a callback function that resets a parameter for a timed effect.
-
-# # Arguments
-# - `eff::TimedEffect`: A TimedEffect with fixed start/end times
-
-# # Returns
-# A `Function` that takes an `integrator` and resets the target parameter in-place
-# """
-# function make_param_reset(eff::TimedEffect)::Function
-#     function effect!(integrator)
-#         current = getproperty(integrator.p, eff.target)
-#         reset_val = eff.reset_func(current)
-#         setproperty!(integrator.p, eff.target, reset_val)
-#     end
-#     return effect!
-# end
-
 """
-    make_save_events(npi::Npi, savepoints)
+    make_save_events(eff::ParamEffect, savepoints)::Union{SavingCallback, Nothing}
 
-Create SavingCallbacks that record compartment values at specified timepoints.
+Create a SavingCallback for a single ParamEffect that records trigger compartment values.
 
-Returns a vector of `SavingCallback`s, one per reactive effect. Each callback captures the
-values of that effect's on/off trigger compartments at each savepoint. TimedEffect
-entries are skipped (they do not require state-based saving).
+Skips timed effects (returns nothing). For reactive effects, creates a callback that captures
+the values of the on/off trigger compartments at each savepoint.
 
 # Arguments
-- `npi::Npi`: Npi struct with a vector of effect specifications (both ReactiveEffect and TimedEffect)
+- `eff::ParamEffect`: An effect with trigger conditions
 - `savepoints`: Time points at which to save state values
 
 # Returns
-A `Vector{SavingCallback}` — one callback per ReactiveEffect, each writing to `eff.saved_values`
+A `SavingCallback` for reactive effects, or `nothing` for timed effects
 """
-function make_save_events(npi::Npi, savepoints)
-    cbset = CallbackSet()
-    for eff in npi.effects
-        # handle comp on
-        if isa(eff.trigger_on, TimeTrigger) && isa(eff.trigger_off, TimeTrigger)
-            continue
-        elseif isa(eff.trigger_on, ReactiveTrigger)
-            idx_on = Constants.get_indices(eff.comp_on.name)
-        end
-        # handle comp off
-        isa(eff, ReactiveEffect) || continue
-        
-        idx_off = Constants.get_indices(eff.comp_off.name)
-
+function make_save_events(eff::ParamEffect, savepoints)
+    # Skip if both triggers are time-based (this is a timed effect)
+    if isa(eff.trigger_on, TimeTrigger) && isa(eff.trigger_off, TimeTrigger)
+        return nothing
+    elseif isa(eff.trigger_on, TimeTrigger)
+        idx_off = Constants.get_indices(eff.trigger_off.name)
+        savingcb = SavingCallback(
+            (u, t, integrator) -> begin
+                sum_off = sum(@view u[idx_off])
+                return (t, sum_off)
+            end,
+            eff.saved_values, saveat = savepoints
+        )
+        return savingcb
+    else
+        # both are reactive
+        idx_on = Constants.get_indices(eff.trigger_on.name)
+        idx_off = Constants.get_indices(eff.trigger_off.name)
         savingcb = SavingCallback(
             (u, t, integrator) -> begin
                 sum_on = sum(@view u[idx_on])
@@ -162,9 +134,48 @@ function make_save_events(npi::Npi, savepoints)
             end,
             eff.saved_values, saveat = savepoints
         )
-        push!(callbacks, savingcb)
+        return savingcb
     end
-    return callbacks
+end
+
+"""
+    make_save_events(npi::Npi, savepoints)
+
+Create SavingCallbacks that record compartment values at specified timepoints.
+
+Returns a vector of `SavingCallback`s, one per reactive effect. Each callback captures the
+values of that effect's on/off trigger compartments at each savepoint. Timed effects
+are skipped (they do not require state-based saving).
+
+# Arguments
+- `npi::Npi`: Npi struct with a vector of effect specifications (both reactive and timed)
+- `savepoints`: Time points at which to save state values
+
+# Returns
+A `Vector{SavingCallback}` — one callback per reactive effect, each writing to `eff.saved_values`
+"""
+function make_save_events(npi::Npi, savepoints)
+    cbset = []
+    for eff in npi.effects
+        cb = make_save_events(eff, savepoints)
+        if !isnothing(cb)
+            push!(cbset, cb)
+        end
+    end
+    return cbset
+end
+
+function make_events(eff::ParamEffect, savepoints)::CallbackSet
+    affect_on! = make_param_changer(eff)
+    affect_off! = make_param_reset(eff)
+
+    tpoints_on = isa(eff.trigger_on, ReactiveTrigger) ? savepoints : eff.trigger_on.value
+    tpoints_off = isa(eff.trigger_off, ReactiveTrigger) ? savepoints : eff.trigger_off.value
+
+    cb_on = PresetTimeCallback(tpoints_on, affect_on!)
+    cb_off = PresetTimeCallback(tpoints_off, affect_off!)
+
+    return CallbackSet(cb_on, cb_off)
 end
 
 """
@@ -172,11 +183,8 @@ end
 
 Create a CallbackSet of event callbacks for an NPI containing both reactive and timed effects.
 
-For ReactiveEffect: generates paired callbacks (on/off) at savepoints, triggered by state.
-For TimedEffect: generates paired callbacks at the effect's start_time and end_time.
-
 # Arguments
-- `npi::Npi`: Npi struct with a vector of effect specifications (ReactiveEffect and/or TimedEffect)
+- `npi::Npi`: Npi struct with a vector of effect specifications
 - `savepoints`: Time points at which to check state for reactive effect triggers
 
 # Returns
@@ -186,20 +194,10 @@ function make_events(npi::Npi, savepoints)::CallbackSet
     cbset = CallbackSet()
 
     for eff in npi.effects
-        affect_on! = make_param_changer(eff)
-        affect_off! = make_param_reset(eff)
+        cbset_eff = make_events(eff, savepoints)
 
-        if isa(eff, ReactiveEffect)
-            # Reactive effects: trigger at savepoints based on state
-            cb_on = PresetTimeCallback(savepoints, affect_on!)
-            cb_off = PresetTimeCallback(savepoints, affect_off!)
-        else  # TimedEffect
-            # Timed effects: trigger at fixed times
-            cb_on = PresetTimeCallback(eff.start_time, affect_on!)
-            cb_off = PresetTimeCallback(eff.end_time, affect_off!)
-        end
-
-        cbset = CallbackSet(cbset, cb_on, cb_off)
+        # cbset grown flexibly
+        cbset = CallbackSet(cbset, cbset_eff)
     end
 
     return cbset
@@ -248,6 +246,5 @@ function make_rt_logger(savepoints)
 
     return pstcb_rt
 end
-
 
 end

--- a/src/Events.jl
+++ b/src/Events.jl
@@ -10,23 +10,20 @@ using LinearAlgebra: eigen, norm
 using OrdinaryDiffEq
 
 export make_events, make_param_changer, make_param_reset,
-       make_save_events, make_rt_logger, make_timed_npi_callbacks, get_coef
+       make_save_events, make_rt_logger, get_coef
 
 """
-    make_param_changer(npi::Npi)::Function
+    make_param_changer(eff::ReactiveEffect)::Function
 
-Create a callback function that modifies all parameters specified in an Npi.
-
-Reads the parameter effects from `npi.effects` and generates a single function that
-applies all modifications at once.
+Create a callback function that modifies a parameter based on reactive state conditions.
 
 # Arguments
-- `npi::Npi`: An Npi struct containing a list of ParamEffect specifications
+- `eff::ReactiveEffect`: A ReactiveEffect with state-dependent trigger conditions
 
 # Returns
-A `Function` that takes an `integrator` and modifies all affected parameters in-place
+A `Function` that takes an `integrator` and modifies the target parameter in-place
 """
-function make_param_changer(eff::ParamEffect)::Function
+function make_param_changer(eff::ReactiveEffect)::Function
     function effect!(integrator)
         if length(eff.saved_values.saveval) > 0
             value_on = eff.comp_on.value
@@ -36,10 +33,6 @@ function make_param_changer(eff::ParamEffect)::Function
                 eff.ison = true
                 original = getproperty(integrator.p, eff.target)
                 new_val = eff.func(original)
-                # TODO: remove
-                # time = integrator.t
-                # println("t = $time Current value $(eff.target) = $original")
-                # println("Setting value $(eff.target) = $new_val")
                 setproperty!(integrator.p, eff.target, new_val)
             end
         else
@@ -50,20 +43,37 @@ function make_param_changer(eff::ParamEffect)::Function
 end
 
 """
-    make_param_reset(npi::Npi)::Function
+    make_param_changer(eff::TimedEffect)::Function
 
-Create a callback function that resets all parameters specified in an Npi.
-
-Reads the parameter names from `npi.effects` and generates a single function that
-resets all of them to their original values.
+Create a callback function that modifies a parameter for a timed effect.
 
 # Arguments
-- `npi::Npi`: An Npi struct containing a list of ParamEffect specifications
+- `eff::TimedEffect`: A TimedEffect with fixed start/end times
 
 # Returns
-A `Function` that takes an `integrator` and resets all affected parameters in-place
+A `Function` that takes an `integrator` and modifies the target parameter in-place
 """
-function make_param_reset(eff::ParamEffect)::Function
+function make_param_changer(eff::TimedEffect)::Function
+    function effect!(integrator)
+        original = getproperty(integrator.p, eff.target)
+        new_val = eff.func(original)
+        setproperty!(integrator.p, eff.target, new_val)
+    end
+    return effect!
+end
+
+"""
+    make_param_reset(eff::ReactiveEffect)::Function
+
+Create a callback function that resets a parameter based on reactive state conditions.
+
+# Arguments
+- `eff::ReactiveEffect`: A ReactiveEffect with state-dependent trigger conditions
+
+# Returns
+A `Function` that takes an `integrator` and resets the target parameter in-place
+"""
+function make_param_reset(eff::ReactiveEffect)::Function
     function effect!(integrator)
         if length(eff.saved_values.saveval) > 0
             value_off = eff.comp_off.value
@@ -83,23 +93,45 @@ function make_param_reset(eff::ParamEffect)::Function
 end
 
 """
+    make_param_reset(eff::TimedEffect)::Function
+
+Create a callback function that resets a parameter for a timed effect.
+
+# Arguments
+- `eff::TimedEffect`: A TimedEffect with fixed start/end times
+
+# Returns
+A `Function` that takes an `integrator` and resets the target parameter in-place
+"""
+function make_param_reset(eff::TimedEffect)::Function
+    function effect!(integrator)
+        current = getproperty(integrator.p, eff.target)
+        reset_val = eff.reset_func(current)
+        setproperty!(integrator.p, eff.target, reset_val)
+    end
+    return effect!
+end
+
+"""
     make_save_events(npi::Npi, savepoints)
 
 Create SavingCallbacks that record compartment values at specified timepoints.
 
-Returns a vector of `SavingCallback`s, one per effect. Each callback captures the
-values of that effect's on/off trigger compartments at each savepoint.
+Returns a vector of `SavingCallback`s, one per reactive effect. Each callback captures the
+values of that effect's on/off trigger compartments at each savepoint. TimedEffect
+entries are skipped (they do not require state-based saving).
 
 # Arguments
-- `npi::Npi`: Reactive NPI struct with a vector of ParamEffect specifications
+- `npi::Npi`: Npi struct with a vector of effect specifications (both ReactiveEffect and TimedEffect)
 - `savepoints`: Time points at which to save state values
 
 # Returns
-A `Vector{SavingCallback}` — one callback per effect, each writing to `eff.saved_values`
+A `Vector{SavingCallback}` — one callback per ReactiveEffect, each writing to `eff.saved_values`
 """
 function make_save_events(npi::Npi, savepoints)
     callbacks = []
     for eff in npi.effects
+        isa(eff, ReactiveEffect) || continue
         idx_on = Constants.get_indices(eff.comp_on.name)
         idx_off = Constants.get_indices(eff.comp_off.name)
 
@@ -119,14 +151,14 @@ end
 """
     make_events(npi::Npi, savepoints)::CallbackSet
 
-Create a CallbackSet of event callbacks for a reactive (state-dependent) NPI.
+Create a CallbackSet of event callbacks for an NPI containing both reactive and timed effects.
 
-Generates paired callbacks (on/off) for each effect in the NPI. Each effect's callbacks
-trigger independently based on that effect's own trigger conditions.
+For ReactiveEffect: generates paired callbacks (on/off) at savepoints, triggered by state.
+For TimedEffect: generates paired callbacks at the effect's start_time and end_time.
 
 # Arguments
-- `npi::Npi`: Reactive NPI struct with a vector of ParamEffect specifications
-- `savepoints`: Time points at which to check state for triggers
+- `npi::Npi`: Npi struct with a vector of effect specifications (ReactiveEffect and/or TimedEffect)
+- `savepoints`: Time points at which to check state for reactive effect triggers
 
 # Returns
 A `CallbackSet` with all on/off callbacks for all effects
@@ -135,15 +167,20 @@ function make_events(npi::Npi, savepoints)::CallbackSet
     cbset = CallbackSet()
 
     for eff in npi.effects
-        # make PSTCb for effect.on for this effect
-        affect_on!::Function = make_param_changer(eff)
-        cb_on = PresetTimeCallback(savepoints, affect_on!)
-        cbset = CallbackSet(cbset, cb_on)
+        affect_on! = make_param_changer(eff)
+        affect_off! = make_param_reset(eff)
 
-        # make PSTCb for effect.off for this effect
-        affect_off!::Function = make_param_reset(eff)
-        cb_off = PresetTimeCallback(savepoints, affect_off!)
-        cbset = CallbackSet(cbset, cb_off)
+        if isa(eff, ReactiveEffect)
+            # Reactive effects: trigger at savepoints based on state
+            cb_on = PresetTimeCallback(savepoints, affect_on!)
+            cb_off = PresetTimeCallback(savepoints, affect_off!)
+        else  # TimedEffect
+            # Timed effects: trigger at fixed times
+            cb_on = PresetTimeCallback(eff.start_time, affect_on!)
+            cb_off = PresetTimeCallback(eff.end_time, affect_off!)
+        end
+
+        cbset = CallbackSet(cbset, cb_on, cb_off)
     end
 
     return cbset
@@ -193,60 +230,5 @@ function make_rt_logger(savepoints)
     return pstcb_rt
 end
 
-"""
-    make_timed_npi_callbacks(npi::TimedNpi)
-
-Create a set of callbacks for time-limited NPIs that activate and deactivate
-at specified times. Each intervention phase applies a transmission reduction
-coefficient to the beta parameter.
-
-# Arguments
-- `npi::TimedNpi`: A TimedNpi struct containing intervention timing and coefficients
-
-# Returns
-- `CallbackSet`: A set of PresetTimeCallback objects that modify beta at the
-  specified intervention times
-
-# Details
-The function creates paired callbacks for each intervention phase:
-- At `start_times[i]`, beta is multiplied by `coefs[i]`
-- At `end_times[i]`, beta is reset to its original value
-
-Between phases, the original beta value is restored. Multiple phases can be
-specified to create complex intervention scenarios.
-
-# Example
-```julia
-timed_npi = TimedNpi([10.0, 30.0], [20.0, 40.0], [0.5, 0.3], "two_phase")
-callbacks = make_timed_npi_callbacks(timed_npi)
-```
-"""
-function make_timed_npi_callbacks(npi::DaedalusStructs.TimedNpi)::CallbackSet
-    callbacks = []
-
-    for (t_on, t_off, coef) in zip(npi.start_times, npi.end_times, npi.coefs)
-        # Create effect function for NPI activation
-        # Multiply beta by the coefficient
-        affect_on! = function (integrator)
-            integrator.p.beta_now = integrator.p.beta * coef
-        end
-
-        # Create callback for activation
-        cb_on = PresetTimeCallback(t_on, affect_on!)
-        push!(callbacks, cb_on)
-
-        # Create effect function for NPI deactivation
-        # Reset beta to original value
-        affect_off! = function (integrator)
-            integrator.p.beta_now = integrator.p.beta
-        end
-
-        # Create callback for deactivation
-        cb_off = PresetTimeCallback(t_off, affect_off!)
-        push!(callbacks, cb_off)
-    end
-
-    return CallbackSet(callbacks...)
-end
 
 end

--- a/src/Events.jl
+++ b/src/Events.jl
@@ -13,54 +13,60 @@ export make_events, make_param_changer, make_param_reset,
        make_save_events, make_rt_logger, get_coef
 
 """
-    make_param_changer(eff::ReactiveEffect)::Function
+    make_param_changer(eff::ParamEffect)::Function
 
 Create a callback function that modifies a parameter based on reactive state conditions.
 
 # Arguments
-- `eff::ReactiveEffect`: A ReactiveEffect with state-dependent trigger conditions
+- `eff::ParamEffect`: A ParamEffect with state-dependent trigger conditions
 
 # Returns
 A `Function` that takes an `integrator` and modifies the target parameter in-place
 """
-function make_param_changer(eff::ReactiveEffect)::Function
+function make_param_changer(eff::ParamEffect)::Function
     function effect!(integrator)
-        if length(eff.saved_values.saveval) > 0
-            value_on = eff.comp_on.value
-            u = eff.saved_values.saveval[end][1] # index 1 for comp_on
-
-            if u > value_on && !eff.ison
-                eff.ison = true
-                original = getproperty(integrator.p, eff.target)
-                new_val = eff.func(original)
-                setproperty!(integrator.p, eff.target, new_val)
-            end
+        # special case for time-dependent NPIs
+        if eff.comp_on.name == "time"
+            original = getproperty(integrator.p, eff.target)
+            new_val = eff.func(original)
+            setproperty!(integrator.p, eff.target, new_val)
         else
-            nothing
+            # all other triggers
+            if length(eff.saved_values.saveval) > 0
+                value_on = eff.comp_on.value
+                u = eff.saved_values.saveval[end][1] # index 1 for comp_on
+                if u > value_on && !eff.ison
+                    eff.ison = true
+                    original = getproperty(integrator.p, eff.target)
+                    new_val = eff.func(original)
+                    setproperty!(integrator.p, eff.target, new_val)
+                end
+            else
+                nothing
+            end
         end
-    end
     return effect!
 end
 
-"""
-    make_param_changer(eff::TimedEffect)::Function
+# """
+#     make_param_changer(eff::TimedEffect)::Function
 
-Create a callback function that modifies a parameter for a timed effect.
+# Create a callback function that modifies a parameter for a timed effect.
 
-# Arguments
-- `eff::TimedEffect`: A TimedEffect with fixed start/end times
+# # Arguments
+# - `eff::TimedEffect`: A TimedEffect with fixed start/end times
 
-# Returns
-A `Function` that takes an `integrator` and modifies the target parameter in-place
-"""
-function make_param_changer(eff::TimedEffect)::Function
-    function effect!(integrator)
-        original = getproperty(integrator.p, eff.target)
-        new_val = eff.func(original)
-        setproperty!(integrator.p, eff.target, new_val)
-    end
-    return effect!
-end
+# # Returns
+# A `Function` that takes an `integrator` and modifies the target parameter in-place
+# """
+# function make_param_changer(eff::TimedEffect)::Function
+#     function effect!(integrator)
+#         original = getproperty(integrator.p, eff.target)
+#         new_val = eff.func(original)
+#         setproperty!(integrator.p, eff.target, new_val)
+#     end
+#     return effect!
+# end
 
 """
     make_param_reset(eff::ReactiveEffect)::Function
@@ -73,44 +79,50 @@ Create a callback function that resets a parameter based on reactive state condi
 # Returns
 A `Function` that takes an `integrator` and resets the target parameter in-place
 """
-function make_param_reset(eff::ReactiveEffect)::Function
+function make_param_reset(eff::ParamEffect)::Function
     function effect!(integrator)
-        if length(eff.saved_values.saveval) > 0
-            value_off = eff.comp_off.value
-            u = eff.saved_values.saveval[end][2] # index 2 for comp_off
-
-            if u < value_off && eff.ison
-                eff.ison = false
-                current = getproperty(integrator.p, eff.target)
-                reset_val = eff.reset_func(current)
-                setproperty!(integrator.p, eff.target, reset_val)
+        if eff.comp_off.name == "time"
+            current = getproperty(integrator.p, eff.target)
+            reset_val = eff.reset_func(current)
+            setproperty!(integrator.p, eff.target, reset_val)
+        else 
+            if length(eff.saved_values.saveval) > 0
+                value_off = eff.comp_off.value
+                u = eff.saved_values.saveval[end][2] # index 2 for comp_off
+    
+                if u < value_off && eff.ison
+                    eff.ison = false
+                    current = getproperty(integrator.p, eff.target)
+                    reset_val = eff.reset_func(current)
+                    setproperty!(integrator.p, eff.target, reset_val)
+                end
+            else
+                nothing
             end
-        else
-            nothing
         end
     end
     return effect!
 end
 
-"""
-    make_param_reset(eff::TimedEffect)::Function
+# """
+#     make_param_reset(eff::TimedEffect)::Function
 
-Create a callback function that resets a parameter for a timed effect.
+# Create a callback function that resets a parameter for a timed effect.
 
-# Arguments
-- `eff::TimedEffect`: A TimedEffect with fixed start/end times
+# # Arguments
+# - `eff::TimedEffect`: A TimedEffect with fixed start/end times
 
-# Returns
-A `Function` that takes an `integrator` and resets the target parameter in-place
-"""
-function make_param_reset(eff::TimedEffect)::Function
-    function effect!(integrator)
-        current = getproperty(integrator.p, eff.target)
-        reset_val = eff.reset_func(current)
-        setproperty!(integrator.p, eff.target, reset_val)
-    end
-    return effect!
-end
+# # Returns
+# A `Function` that takes an `integrator` and resets the target parameter in-place
+# """
+# function make_param_reset(eff::TimedEffect)::Function
+#     function effect!(integrator)
+#         current = getproperty(integrator.p, eff.target)
+#         reset_val = eff.reset_func(current)
+#         setproperty!(integrator.p, eff.target, reset_val)
+#     end
+#     return effect!
+# end
 
 """
     make_save_events(npi::Npi, savepoints)
@@ -129,10 +141,17 @@ entries are skipped (they do not require state-based saving).
 A `Vector{SavingCallback}` — one callback per ReactiveEffect, each writing to `eff.saved_values`
 """
 function make_save_events(npi::Npi, savepoints)
-    callbacks = []
+    cbset = CallbackSet()
     for eff in npi.effects
+        # handle comp on
+        if isa(eff.trigger_on, TimeTrigger) && isa(eff.trigger_off, TimeTrigger)
+            continue
+        elseif isa(eff.trigger_on, ReactiveTrigger)
+            idx_on = Constants.get_indices(eff.comp_on.name)
+        end
+        # handle comp off
         isa(eff, ReactiveEffect) || continue
-        idx_on = Constants.get_indices(eff.comp_on.name)
+        
         idx_off = Constants.get_indices(eff.comp_off.name)
 
         savingcb = SavingCallback(

--- a/src/Events.jl
+++ b/src/Events.jl
@@ -9,61 +9,8 @@ using DiffEqCallbacks: SavedValues, SavingCallback, PresetTimeCallback
 using LinearAlgebra: eigen, norm
 using OrdinaryDiffEq
 
-export make_state_condition,
-       make_events, make_param_changer, make_param_reset,
+export make_events, make_param_changer, make_param_reset,
        make_save_events, make_rt_logger, make_timed_npi_callbacks, get_coef
-
-"""
-    make_state_condition(threshold, idx, comparison)::Function
-
-Factory function that creates a condition function for event callbacks.
-
-Returns a function that checks whether a state sum crosses a threshold at the
-specified indices. Used to trigger events when compartment totals reach certain values.
-
-# Arguments
-- `threshold::Float64`: The threshold value for comparison
-- `idx`: Indices into the state vector to sum
-- `comparison::Function`: Comparison function (e.g., `<`, `>`)
-
-# Returns
-A `Function` that takes `(u, t, integrator)` and returns 0.0 if condition is met, 1.0 otherwise
-"""
-function make_state_condition(threshold, idx, comparison::Function)::Function
-    function fn_cond(u, t, integrator)
-        state_sum = 0.0
-
-        X = @view u[idx]
-        state_sum = sum(X)
-
-        return comparison(state_sum, threshold) ? 0.0 : 1.0
-    end
-
-    return fn_cond
-end
-
-"""
-    make_param_changer(param_name, func, coef)::Function
-
-Create a callback function that modifies a parameter during ODE integration.
-
-Generates an effect function that applies `func` to the current parameter value
-multiplied by `coef`, storing the result in `param_name_now`.
-
-# Arguments
-- `param_name::String`: Name of the parameter to modify (e.g., `"beta"`)
-- `func::Function`: Function to apply (e.g., `.*` for multiplication)
-- `coef`: Coefficient to apply via `func`
-
-# Returns
-A `Function` that takes an `integrator` and modifies the parameter in-place
-"""
-function make_param_changer(param_name, func, coef)::Function
-    function effect!(integrator)
-        new_value = func(getproperty(integrator.p, Symbol(param_name)), coef)
-        setproperty!(integrator.p, Symbol(param_name * "_now"), new_value)
-    end
-end
 
 """
     make_param_changer(npi::Npi)::Function
@@ -79,34 +26,27 @@ applies all modifications at once.
 # Returns
 A `Function` that takes an `integrator` and modifies all affected parameters in-place
 """
-function make_param_changer(npi::Npi)::Function
+function make_param_changer(eff::ParamEffect)::Function
     function effect!(integrator)
-        for eff in npi.effects
-            original = getproperty(integrator.p, eff.name)
-            new_val = eff.func(original)
-            param_now = Symbol(String(eff.name) * "_now")
-            setproperty!(integrator.p, param_now, new_val)
+        if length(eff.saved_values.saveval) > 0
+            value_on = eff.comp_on.value
+            u = eff.saved_values.saveval[end][1] # index 1 for comp_on
+
+            if u > value_on && !eff.ison
+                eff.ison = true
+                original = getproperty(integrator.p, eff.target)
+                new_val = eff.func(original)
+                # TODO: remove
+                # time = integrator.t
+                # println("t = $time Current value $(eff.target) = $original")
+                # println("Setting value $(eff.target) = $new_val")
+                setproperty!(integrator.p, eff.target, new_val)
+            end
+        else
+            nothing
         end
     end
     return effect!
-end
-
-"""
-    make_param_reset(param_name)::Function
-
-Create a callback function that resets a parameter to its original value.
-
-# Arguments
-- `param_name::String`: Name of the parameter to reset (e.g., `"beta"`)
-
-# Returns
-A `Function` that takes an `integrator` and resets `param_name_now` to the original `param_name`
-"""
-function make_param_reset(param_name)::Function
-    function effect!(integrator)
-        original_value = getproperty(integrator.p, Symbol(param_name))
-        setproperty!(integrator.p, Symbol(param_name * "_now"), original_value)
-    end
 end
 
 """
@@ -123,12 +63,20 @@ resets all of them to their original values.
 # Returns
 A `Function` that takes an `integrator` and resets all affected parameters in-place
 """
-function make_param_reset(npi::Npi)::Function
+function make_param_reset(eff::ParamEffect)::Function
     function effect!(integrator)
-        for eff in npi.effects
-            original = getproperty(integrator.p, eff.name)
-            param_now = Symbol(String(eff.name) * "_now")
-            setproperty!(integrator.p, param_now, original)
+        if length(eff.saved_values.saveval) > 0
+            value_off = eff.comp_off.value
+            u = eff.saved_values.saveval[end][2] # index 2 for comp_off
+
+            if u < value_off && eff.ison
+                eff.ison = false
+                current = getproperty(integrator.p, eff.target)
+                reset_val = eff.reset_func(current)
+                setproperty!(integrator.p, eff.target, reset_val)
+            end
+        else
+            nothing
         end
     end
     return effect!
@@ -157,8 +105,8 @@ function make_save_events(npi::Npi, savepoints)
 
         savingcb = SavingCallback(
             (u, t, integrator) -> begin
-                sum_on = sum(u[idx_on])
-                sum_off = sum(u[idx_off])
+                sum_on = sum(@view u[idx_on])
+                sum_off = sum(@view u[idx_off])
                 return (sum_on, sum_off)
             end,
             eff.saved_values, saveat = savepoints
@@ -184,54 +132,21 @@ trigger independently based on that effect's own trigger conditions.
 A `CallbackSet` with all on/off callbacks for all effects
 """
 function make_events(npi::Npi, savepoints)::CallbackSet
-    callbacks = []
+    cbset = CallbackSet()
 
     for eff in npi.effects
-        value_on = eff.comp_on.value
-        value_off = eff.comp_off.value
-        param_now_sym = Symbol(String(eff.name) * "_now")
-
-        # Activation callback
-        function affect_on!(integrator)
-            if length(eff.saved_values.saveval) < 2
-                return nothing
-            end
-
-            u = eff.saved_values.saveval[end][1]      # latest sum_on
-            _u = eff.saved_values.saveval[end - 1][1] # previous sum_on
-            growing = u > _u
-
-            if u > value_on && growing && !eff.ison
-                eff.ison = true
-                original = getproperty(integrator.p, eff.name)
-                new_val = eff.func(original)
-                setproperty!(integrator.p, param_now_sym, new_val)
-            end
-        end
-
+        # make PSTCb for effect.on for this effect
+        affect_on!::Function = make_param_changer(eff)
         cb_on = PresetTimeCallback(savepoints, affect_on!)
-        push!(callbacks, cb_on)
+        cbset = CallbackSet(cbset, cb_on)
 
-        # Deactivation callback
-        function affect_off!(integrator)
-            if length(eff.saved_values.saveval) == 0
-                return nothing
-            end
-
-            u = eff.saved_values.saveval[end][2]  # latest sum_off
-
-            if u < value_off && eff.ison
-                eff.ison = false
-                original = getproperty(integrator.p, eff.name)
-                setproperty!(integrator.p, param_now_sym, original)
-            end
-        end
-
+        # make PSTCb for effect.off for this effect
+        affect_off!::Function = make_param_reset(eff)
         cb_off = PresetTimeCallback(savepoints, affect_off!)
-        push!(callbacks, cb_off)
+        cbset = CallbackSet(cbset, cb_off)
     end
 
-    return CallbackSet(callbacks...)
+    return cbset
 end
 
 """

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -365,7 +365,7 @@ function daedalus(
         nothing
     elseif isa(npi, Npi)
         # TODO: write fn to extract saves
-        [eff.saved_values for eff in npi.effects if isa(eff, ReactiveEffect)]
+        [eff.saved_values for eff in npi.effects if isa(eff, ParamEffect)]
     else
         nothing
     end

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -29,7 +29,7 @@ and infection parameters, with optional non-pharmaceutical interventions.
   - A [`DataLoader.InfectionData`](@ref) struct with all epidemiological parameters
   - A `Vector{DataLoader.InfectionData}` for ensemble runs with multiple pathogens (R0s extracted)
 - `npi`: Non-pharmaceutical intervention. Can be:
-  - `Npi`: Container of parameter effects (ReactiveEffect for state-dependent, TimedEffect for time-limited)
+  - `Npi`: Container of parameter effects (each with `ReactiveTrigger` or `TimeTrigger` conditions)
   - `nothing`: No intervention (default)
 - `log_rt`: Whether to compute and log effective reproduction number (default: true)
 - `time_end`: Simulation end time in days (default: 100.0)
@@ -58,7 +58,9 @@ result = daedalus("Australia", infection, time_end=200.0)
 
 ## Time-limited intervention
 ```julia
-effect = Daedalus.DaedalusStructs.TimedEffect(:beta, x -> x .* 0.7, x -> x ./ 0.7, 15.0, 45.0)
+trigger_on = Daedalus.DaedalusStructs.TimeTrigger(15.0)
+trigger_off = Daedalus.DaedalusStructs.TimeTrigger(45.0)
+effect = Daedalus.DaedalusStructs.ParamEffect(:beta, x -> x .* 0.7, x -> x ./ 0.7, trigger_on, trigger_off)
 npi = Daedalus.DaedalusStructs.Npi([effect])
 result = daedalus("Australia", "sars-cov-2 delta", time_end=200.0, npi=npi)
 ```

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -29,8 +29,7 @@ and infection parameters, with optional non-pharmaceutical interventions.
   - A [`DataLoader.InfectionData`](@ref) struct with all epidemiological parameters
   - A `Vector{DataLoader.InfectionData}` for ensemble runs with multiple pathogens (R0s extracted)
 - `npi`: Non-pharmaceutical intervention. Can be:
-  - `Npi`: Reactive NPI that responds to epidemic state (hospitalizations, Rt)
-  - `TimedNpi`: Time-limited NPI with predefined start/end times
+  - `Npi`: Container of parameter effects (ReactiveEffect for state-dependent, TimedEffect for time-limited)
   - `nothing`: No intervention (default)
 - `log_rt`: Whether to compute and log effective reproduction number (default: true)
 - `time_end`: Simulation end time in days (default: 100.0)
@@ -59,7 +58,8 @@ result = daedalus("Australia", infection, time_end=200.0)
 
 ## Time-limited intervention
 ```julia
-npi = TimedNpi(15.0, 45.0, 0.7, "moderate_lockdown")
+effect = Daedalus.DaedalusStructs.TimedEffect(:beta, x -> x .* 0.7, x -> x ./ 0.7, 15.0, 45.0)
+npi = Daedalus.DaedalusStructs.Npi([effect])
 result = daedalus("Australia", "sars-cov-2 delta", time_end=200.0, npi=npi)
 ```
 
@@ -273,7 +273,7 @@ end
 
 # Method 1: String pathogen name - fetch and delegate to InfectionData method
 function daedalus(country::Union{String, DataLoader.CountryData}, infection::String;
-        npi::Union{Npi, TimedNpi, Nothing} = nothing,
+        npi::Union{Npi, Nothing} = nothing,
         log_rt::Bool = true,
         time_end::Float64 = 100.0,
         increment::Float64 = 1.0,
@@ -286,7 +286,7 @@ end
 # Method 2: Single InfectionData object
 function daedalus(
         country::Union{String, DataLoader.CountryData}, infection::DataLoader.InfectionData;
-        npi::Union{Npi, TimedNpi, Nothing} = nothing,
+        npi::Union{Npi, Nothing} = nothing,
         log_rt::Bool = true,
         time_end::Float64 = 100.0,
         increment::Float64 = 1.0,
@@ -344,14 +344,6 @@ function daedalus(
             rt_logger = make_rt_logger(savepoints)
             cb_set = CallbackSet(rt_logger)
         end
-    elseif isa(npi, TimedNpi)
-        timed_callbacks = make_timed_npi_callbacks(npi)
-        if log_rt
-            rt_logger = make_rt_logger(savepoints)
-            cb_set = CallbackSet(timed_callbacks, rt_logger)
-        else
-            cb_set = timed_callbacks
-        end
     elseif isa(npi, Npi)
         save_events = make_save_events(npi, savepoints)
         events = make_events(npi, savepoints)
@@ -372,7 +364,7 @@ function daedalus(
     saved_vals = if isnothing(npi)
         nothing
     elseif isa(npi, Npi)
-        [eff.saved_values for eff in npi.effects]
+        [eff.saved_values for eff in npi.effects if isa(eff, ReactiveEffect)]
     else
         nothing
     end

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -364,6 +364,7 @@ function daedalus(
     saved_vals = if isnothing(npi)
         nothing
     elseif isa(npi, Npi)
+        # TODO: write fn to extract saves
         [eff.saved_values for eff in npi.effects if isa(eff, ReactiveEffect)]
     else
         nothing

--- a/src/Ode.jl
+++ b/src/Ode.jl
@@ -67,7 +67,7 @@ function daedalus_ode!(du::Array, u::Array, p::Params, t::Number)
     cm_scaling = ones(p.settings) # NOTE: placeholder for future operations
     weighted_slice_sum!(p.contacts, cm_scaling, p.cm_temp)
 
-    foi = p.beta_now * p.cm_temp * community_infectious
+    foi = p.beta * p.cm_temp * community_infectious
 
     # NOTE: element-wise multiplication
     new_I = S .* foi
@@ -106,7 +106,7 @@ function daedalus_ode!(du::Array, u::Array, p::Params, t::Number)
     @. dIa = (p.sigma * E) * (1.0 - p.p_sigma) - (p.gamma_Ia * Ia)
 
     # change in hospitalised
-    @. dH = (p.eta .* Is) - ((p.gamma_H + p.omega_now) .* H)
+    @. dH = (p.eta .* Is) - ((p.gamma_H + p.omega) .* H)
 
     # change in recovered
     @. dR = (p.gamma_Ia * Ia) + (p.gamma_Is * Is) +
@@ -116,7 +116,7 @@ function daedalus_ode!(du::Array, u::Array, p::Params, t::Number)
     @. dR[:, 2] += (new_Rvax * nu_eff - new_Rwane * p.psi)
 
     # change in dead
-    @. dD = p.omega_now .* H
+    @. dD = p.omega .* H
 
     # Rt is updated by callbacks; keep its derivative zero between updates
     du[end] = 0.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,9 @@ using Test
     # Include eigenvalue tests
     include("test_eigenvalue.jl")
 
+    # Include trigger and effect tests
+    include("test_triggers_effects.jl")
+
     # Include time-limited NPI tests
     include("test_timed_npi.jl")
 

--- a/test/test_eigenvalue.jl
+++ b/test/test_eigenvalue.jl
@@ -201,10 +201,12 @@ end
     end
 
     @testset "Rt with NPI intervention" begin
-        # Create a simple NPI for testing (new style with ReactiveEffect)
-        effect = Daedalus.DaedalusStructs.ReactiveEffect(
-            :beta, x -> x .* 0.7, x -> x ./ 0.7;
-            on = ("H", 20000.0), off = ("Rt", 1.0)
+        # Create a simple NPI for testing with ParamEffect
+        trigger_on = Daedalus.DaedalusStructs.ReactiveTrigger(20000.0, "H")
+        trigger_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.7, x -> x ./ 0.7,
+            trigger_on, trigger_off
         )
         npi = Daedalus.DaedalusStructs.Npi([effect])
 

--- a/test/test_eigenvalue.jl
+++ b/test/test_eigenvalue.jl
@@ -201,8 +201,8 @@ end
     end
 
     @testset "Rt with NPI intervention" begin
-        # Create a simple NPI for testing (new style with ParamEffect)
-        effect = Daedalus.DaedalusStructs.ParamEffect(
+        # Create a simple NPI for testing (new style with ReactiveEffect)
+        effect = Daedalus.DaedalusStructs.ReactiveEffect(
             :beta, x -> x .* 0.7, x -> x ./ 0.7;
             on = ("H", 20000.0), off = ("Rt", 1.0)
         )

--- a/test/test_eigenvalue.jl
+++ b/test/test_eigenvalue.jl
@@ -203,7 +203,7 @@ end
     @testset "Rt with NPI intervention" begin
         # Create a simple NPI for testing (new style with ParamEffect)
         effect = Daedalus.DaedalusStructs.ParamEffect(
-            :beta, original -> original .* 0.7;
+            :beta, x -> x .* 0.7, x -> x ./ 0.7;
             on = ("H", 20000.0), off = ("Rt", 1.0)
         )
         npi = Daedalus.DaedalusStructs.Npi([effect])

--- a/test/test_timed_npi.jl
+++ b/test/test_timed_npi.jl
@@ -3,237 +3,53 @@ using Test
 using OrdinaryDiffEq
 using DiffEqCallbacks
 
-@testset "TimedNpi construction and validation" begin
-    @testset "Valid single-phase construction" begin
-        npi = Daedalus.DaedalusStructs.TimedNpi(10.0, 20.0, 0.5, "test")
-
-        @test npi.start_times == [10.0]
-        @test npi.end_times == [20.0]
-        @test npi.coefs == [0.5]
-        @test npi.identifier == "test"
-    end
-
-    @testset "Valid multi-phase construction" begin
-        start_times = [10.0, 30.0, 60.0]
-        end_times = [25.0, 55.0, 90.0]
-        coefs = [0.7, 0.3, 0.5]
-
-        npi = Daedalus.DaedalusStructs.TimedNpi(
-            start_times, end_times, coefs, "multi_phase"
+@testset "make_events with timed effects" begin
+    @testset "Callback creation for single timed phase" begin
+        effect = Daedalus.DaedalusStructs.TimedEffect(
+            :beta, x -> x .* 0.5, x -> x ./ 0.5, 10.0, 20.0
         )
-
-        @test npi.start_times == start_times
-        @test npi.end_times == end_times
-        @test npi.coefs == coefs
-        @test npi.identifier == "multi_phase"
-    end
-
-    @testset "Default identifier" begin
-        npi = Daedalus.DaedalusStructs.TimedNpi([10.0], [20.0], [0.5])
-        @test npi.identifier == "custom_timed"
-    end
-
-    @testset "Convenience constructor defaults" begin
-        npi = Daedalus.DaedalusStructs.TimedNpi(10.0, 20.0, 0.5)
-        @test npi.identifier == "single_phase"
-        @test length(npi.start_times) == 1
-    end
-
-    @testset "Validation: mismatched vector lengths" begin
-        @test_throws ArgumentError Daedalus.DaedalusStructs.TimedNpi(
-            [10.0, 20.0], [30.0], [0.5, 0.3]
-        )
-
-        @test_throws ArgumentError Daedalus.DaedalusStructs.TimedNpi(
-            [10.0], [30.0, 40.0], [0.5]
-        )
-
-        @test_throws ArgumentError Daedalus.DaedalusStructs.TimedNpi(
-            [10.0, 20.0], [30.0, 40.0], [0.5]
-        )
-    end
-
-    @testset "Validation: negative times" begin
-        @test_throws ArgumentError Daedalus.DaedalusStructs.TimedNpi(
-            [-10.0], [20.0], [0.5]
-        )
-
-        @test_throws ArgumentError Daedalus.DaedalusStructs.TimedNpi(
-            [10.0], [-20.0], [0.5]
-        )
-    end
-
-    @testset "Validation: end_time < start_time" begin
-        @test_throws ArgumentError Daedalus.DaedalusStructs.TimedNpi(
-            [20.0], [10.0], [0.5]
-        )
-
-        @test_throws ArgumentError Daedalus.DaedalusStructs.TimedNpi(
-            [10.0, 40.0], [25.0, 35.0], [0.5, 0.3]  # second phase: 40 > 35 invalid
-        )
-    end
-
-    @testset "Validation: unsorted times" begin
-        @test_throws ArgumentError Daedalus.DaedalusStructs.TimedNpi(
-            [30.0, 10.0], [40.0, 20.0], [0.5, 0.3]
-        )
-
-        @test_throws ArgumentError Daedalus.DaedalusStructs.TimedNpi(
-            [10.0, 30.0], [40.0, 20.0], [0.5, 0.3]
-        )
-    end
-
-    @testset "Validation: overlapping intervals" begin
-        # Phase 1: 10-30, Phase 2: 25-40 (overlaps!)
-        @test_throws ArgumentError Daedalus.DaedalusStructs.TimedNpi(
-            [10.0, 25.0], [30.0, 40.0], [0.5, 0.3]
-        )
-
-        # Phase 1: 10-30, Phase 2: 30-40 (exactly adjacent - should fail)
-        @test_throws ArgumentError Daedalus.DaedalusStructs.TimedNpi(
-            [10.0, 30.0], [30.0, 40.0], [0.5, 0.3]
-        )
-    end
-
-    @testset "Validation: coefficients out of range" begin
-        @test_throws ArgumentError Daedalus.DaedalusStructs.TimedNpi(
-            [10.0], [20.0], [1.5]
-        )
-
-        @test_throws ArgumentError Daedalus.DaedalusStructs.TimedNpi(
-            [10.0], [20.0], [-0.1]
-        )
-
-        @test_throws ArgumentError Daedalus.DaedalusStructs.TimedNpi(
-            [10.0, 30.0], [20.0, 40.0], [0.5, 1.1]
-        )
-    end
-
-    @testset "Boundary values: zero duration phase" begin
-        # Start and end at same time (zero duration)
-        npi = Daedalus.DaedalusStructs.TimedNpi([10.0], [10.0], [0.5])
-        @test npi.start_times == [10.0]
-        @test npi.end_times == [10.0]
-    end
-
-    @testset "Boundary values: coefficient limits" begin
-        # Coefficient = 0 (complete transmission block)
-        npi1 = Daedalus.DaedalusStructs.TimedNpi([10.0], [20.0], [0.0])
-        @test npi1.coefs == [0.0]
-
-        # Coefficient = 1 (no intervention effect)
-        npi2 = Daedalus.DaedalusStructs.TimedNpi([10.0], [20.0], [1.0])
-        @test npi2.coefs == [1.0]
-    end
-
-    @testset "Non-overlapping intervals with gap" begin
-        # Phase 1: 10-20, gap, Phase 2: 25-35 (valid)
-        npi = Daedalus.DaedalusStructs.TimedNpi(
-            [10.0, 25.0], [20.0, 35.0], [0.5, 0.3]
-        )
-        @test npi.start_times == [10.0, 25.0]
-        @test npi.end_times == [20.0, 35.0]
-    end
-end
-
-@testset "TimedNpi helper functions" begin
-    @testset "n_phases" begin
-        npi1 = Daedalus.DaedalusStructs.TimedNpi(10.0, 20.0, 0.5)
-        @test Daedalus.DaedalusStructs.n_phases(npi1) == 1
-
-        npi3 = Daedalus.DaedalusStructs.TimedNpi(
-            [10.0, 30.0, 60.0],
-            [20.0, 50.0, 80.0],
-            [0.7, 0.3, 0.5]
-        )
-        @test Daedalus.DaedalusStructs.n_phases(npi3) == 3
-    end
-
-    @testset "total_duration" begin
-        # Single phase: 10 days
-        npi1 = Daedalus.DaedalusStructs.TimedNpi(10.0, 20.0, 0.5)
-        @test Daedalus.DaedalusStructs.total_duration(npi1) == 10.0
-
-        # Three phases: 10 + 20 + 20 = 50 days total
-        npi3 = Daedalus.DaedalusStructs.TimedNpi(
-            [10.0, 30.0, 60.0],
-            [20.0, 50.0, 80.0],
-            [0.7, 0.3, 0.5]
-        )
-        @test Daedalus.DaedalusStructs.total_duration(npi3) == 50.0
-
-        # Zero duration phase
-        npi_zero = Daedalus.DaedalusStructs.TimedNpi([10.0], [10.0], [0.5])
-        @test Daedalus.DaedalusStructs.total_duration(npi_zero) == 0.0
-    end
-
-    @testset "Base.show" begin
-        npi = Daedalus.DaedalusStructs.TimedNpi(
-            [10.0, 30.0],
-            [20.0, 40.0],
-            [0.7, 0.3],
-            "test_display"
-        )
-
-        # Capture output
-        io = IOBuffer()
-        show(io, npi)
-        output = String(take!(io))
-
-        @test occursin("TimedNpi: test_display", output)
-        @test occursin("Number of phases: 2", output)
-        @test occursin("Total duration: 20.0 days", output)
-        @test occursin("Phase 1", output)
-        @test occursin("Phase 2", output)
-    end
-end
-
-@testset "make_timed_npi_callbacks" begin
-    @testset "Callback creation for single phase" begin
-        npi = Daedalus.DaedalusStructs.TimedNpi(10.0, 20.0, 0.5)
-        callbacks = Daedalus.Events.make_timed_npi_callbacks(npi)
+        npi = Daedalus.DaedalusStructs.Npi([effect])
+        savepoints = 0.0:1.0:30.0
+        callbacks = Daedalus.Events.make_events(npi, savepoints)
 
         @test isa(callbacks, DiffEqCallbacks.CallbackSet)
-        # Should have 2 callbacks: one for activation, one for deactivation
+        # Should have 2 callbacks: one for activation at start_time, one for deactivation at end_time
         @test length(callbacks.discrete_callbacks) == 2
     end
 
-    @testset "Callback creation for multiple phases" begin
-        npi = Daedalus.DaedalusStructs.TimedNpi(
-            [10.0, 30.0, 60.0],
-            [20.0, 40.0, 80.0],
-            [0.7, 0.3, 0.5]
+    @testset "Callback creation for multiple timed phases" begin
+        effect1 = Daedalus.DaedalusStructs.TimedEffect(
+            :beta, x -> x .* 0.7, x -> x ./ 0.7, 10.0, 20.0
         )
-        callbacks = Daedalus.Events.make_timed_npi_callbacks(npi)
+        effect2 = Daedalus.DaedalusStructs.TimedEffect(
+            :beta, x -> x .* 0.3, x -> x ./ 0.3, 30.0, 40.0
+        )
+        effect3 = Daedalus.DaedalusStructs.TimedEffect(
+            :beta, x -> x .* 0.5, x -> x ./ 0.5, 60.0, 80.0
+        )
+        npi = Daedalus.DaedalusStructs.Npi([effect1, effect2, effect3])
+        savepoints = 0.0:1.0:100.0
+        callbacks = Daedalus.Events.make_events(npi, savepoints)
 
         @test isa(callbacks, DiffEqCallbacks.CallbackSet)
-        # Should have 6 callbacks: 2 per phase (on/off)
+        # Should have 6 callbacks: 2 per effect (on/off)
         @test length(callbacks.discrete_callbacks) == 6
-    end
-
-    @testset "Callback times are correct" begin
-        npi = Daedalus.DaedalusStructs.TimedNpi(
-            [15.0, 45.0],
-            [30.0, 60.0],
-            [0.6, 0.4]
-        )
-        callbacks = Daedalus.Events.make_timed_npi_callbacks(npi)
-
-        # Extract callback times (this is implementation-specific)
-        # The callbacks should trigger at times: 15, 30, 45, 60
-        @test length(callbacks.discrete_callbacks) == 4
     end
 end
 
-@testset "TimedNpi integration with daedalus model" begin
-    @testset "Model runs with single-phase TimedNpi" begin
-        npi = Daedalus.DaedalusStructs.TimedNpi(15.0, 45.0, 0.5, "test_single")
-        infection_single = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
-        infection_single.r0 = 2.0
+@testset "TimedEffect integration with daedalus model" begin
+    @testset "Model runs with single timed effect" begin
+        effect = Daedalus.DaedalusStructs.TimedEffect(
+            :beta, x -> x .* 0.5, x -> x ./ 0.5, 15.0, 45.0
+        )
+        npi = Daedalus.DaedalusStructs.Npi([effect])
+
+        infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
+        infection.r0 = 2.0
 
         result = Daedalus.daedalus(
             "Australia",
-            infection_single,
+            infection,
             time_end = 80.0,
             increment = 1.0,
             npi = npi,
@@ -242,16 +58,20 @@ end
 
         @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
         @test result.npi === npi
-        @test isnothing(result.saves)  # TimedNpi has no saved values
+        @test isnothing(result.saves)  # TimedEffect has no saved values
     end
 
-    @testset "Model runs with multi-phase TimedNpi" begin
-        npi = Daedalus.DaedalusStructs.TimedNpi(
-            [10.0, 30.0, 60.0],
-            [25.0, 50.0, 75.0],
-            [0.7, 0.4, 0.6],
-            "test_multi"
+    @testset "Model runs with multiple timed effects" begin
+        effect1 = Daedalus.DaedalusStructs.TimedEffect(
+            :beta, x -> x .* 0.7, x -> x ./ 0.7, 10.0, 25.0
         )
+        effect2 = Daedalus.DaedalusStructs.TimedEffect(
+            :beta, x -> x .* 0.4, x -> x ./ 0.4, 30.0, 50.0
+        )
+        effect3 = Daedalus.DaedalusStructs.TimedEffect(
+            :beta, x -> x .* 0.6, x -> x ./ 0.6, 60.0, 75.0
+        )
+        npi = Daedalus.DaedalusStructs.Npi([effect1, effect2, effect3])
 
         result = Daedalus.daedalus(
             "Australia",
@@ -268,7 +88,10 @@ end
     end
 
     @testset "Model runs without Rt logging" begin
-        npi = Daedalus.DaedalusStructs.TimedNpi(20.0, 40.0, 0.3)
+        effect = Daedalus.DaedalusStructs.TimedEffect(
+            :beta, x -> x .* 0.3, x -> x ./ 0.3, 20.0, 40.0
+        )
+        npi = Daedalus.DaedalusStructs.Npi([effect])
 
         result = Daedalus.daedalus(
             "Australia",
@@ -280,139 +103,11 @@ end
 
         @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
     end
-
-    @testset "Model output structure is correct" begin
-        npi = Daedalus.DaedalusStructs.TimedNpi(10.0, 30.0, 0.5)
-
-        result = Daedalus.daedalus(
-            "Australia",
-            "sars-cov-1",
-            time_end = 50.0,
-            increment = 1.0,
-            npi = npi
-        )
-
-        @test haskey(result, :sol)
-        @test haskey(result, :saves)
-        @test haskey(result, :npi)
-        @test result.npi === npi
-    end
-
-    @testset "Solution has correct time points" begin
-        npi = Daedalus.DaedalusStructs.TimedNpi(15.0, 35.0, 0.4)
-
-        result = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 50.0,
-            increment = 1.0,
-            npi = npi
-        )
-
-        # Should have savepoints at each day from 0 to 50
-        @test length(unique(result.sol.t)) == 51
-        @test result.sol.t[1] == 0.0
-        @test result.sol.t[end] == 50.0
-    end
-
-    @testset "Extreme coefficient values" begin
-        # Complete transmission block (coef = 0)
-        npi_block = Daedalus.DaedalusStructs.TimedNpi(10.0, 30.0, 0.0)
-        result_block = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 50.0,
-            npi = npi_block
-        )
-        @test result_block.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-
-        # No intervention effect (coef = 1)
-        npi_none = Daedalus.DaedalusStructs.TimedNpi(10.0, 30.0, 1.0)
-        result_none = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 50.0,
-            npi = npi_none
-        )
-        @test result_none.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-    end
-
-    @testset "NPI at simulation boundaries" begin
-        # NPI starting at time 0
-        npi_start = Daedalus.DaedalusStructs.TimedNpi(0.0, 20.0, 0.5)
-        result_start = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 40.0,
-            npi = npi_start
-        )
-        @test result_start.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-
-        # NPI ending at simulation end
-        npi_end = Daedalus.DaedalusStructs.TimedNpi(20.0, 50.0, 0.5)
-        result_end = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 50.0,
-            npi = npi_end
-        )
-        @test result_end.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-
-        # NPI covering entire simulation
-        npi_full = Daedalus.DaedalusStructs.TimedNpi(0.0, 50.0, 0.5)
-        result_full = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 50.0,
-            npi = npi_full
-        )
-        @test result_full.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-    end
 end
 
-@testset "TimedNpi vs no intervention comparison" begin
-    @testset "Basic epidemic comparison" begin
-        # Run without intervention
-        result_none = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 100.0,
-            increment = 1.0,
-            log_rt = true
-        )
-
-        # Run with intervention
-        npi = Daedalus.DaedalusStructs.TimedNpi(20.0, 60.0, 0.3)
-        result_npi = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 100.0,
-            increment = 1.0,
-            npi = npi,
-            log_rt = true
-        )
-
-        # Both should complete successfully
-        @test result_none.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-        @test result_npi.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-
-        # Should have same number of time points
-        @test length(unique(result_none.sol.t)) == length(unique(result_npi.sol.t))
-
-        # Intervention should generally reduce epidemic size
-        # (not guaranteed for all parameter combinations, but should be true here)
-        iExposed = Daedalus.Constants.get_indices("E")
-        exposed_none = [sum(u[iExposed]) for u in result_none.sol.u]
-        exposed_npi = [sum(u[iExposed]) for u in result_npi.sol.u]
-
-        # Peak exposure should be lower with intervention
-        @test maximum(exposed_npi) < maximum(exposed_none)
-    end
-end
-
-@testset "TimedNpi vs reactive Npi coexistence" begin
+@testset "TimedEffect and reactive Npi coexistence" begin
     @testset "Model accepts reactive Npi (unchanged behavior)" begin
-        effect = Daedalus.DaedalusStructs.ParamEffect(
+        effect = Daedalus.DaedalusStructs.ReactiveEffect(
             :beta, x -> x .* 0.4, x -> x ./ 0.4;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
@@ -444,96 +139,9 @@ end
     end
 end
 
-@testset "Edge cases and stress tests" begin
-    @testset "Very short intervention duration" begin
-        # 0.1 day intervention
-        npi = Daedalus.DaedalusStructs.TimedNpi(20.0, 20.1, 0.5)
-        result = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 40.0,
-            increment = 0.1,
-            npi = npi
-        )
-        @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-    end
-
-    @testset "Very long intervention duration" begin
-        # 200 day intervention
-        npi = Daedalus.DaedalusStructs.TimedNpi(10.0, 210.0, 0.3)
-        result = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 250.0,
-            npi = npi
-        )
-        @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-    end
-
-    @testset "Many phases" begin
-        # 10 phases with 5-day gaps
-        start_times = collect(0.0:10.0:90.0)
-        end_times = start_times .+ 5.0
-        coefs = fill(0.5, 10)
-
-        npi = Daedalus.DaedalusStructs.TimedNpi(
-            start_times, end_times, coefs, "many_phases"
-        )
-        result = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 120.0,
-            npi = npi
-        )
-        @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-        @test Daedalus.DaedalusStructs.n_phases(npi) == 10
-    end
-
-    @testset "Alternating intensity phases" begin
-        # High-low-high-low pattern
-        npi = Daedalus.DaedalusStructs.TimedNpi(
-            [10.0, 30.0, 50.0, 70.0],
-            [25.0, 45.0, 65.0, 85.0],
-            [0.2, 0.8, 0.2, 0.8],
-            "alternating"
-        )
-        result = Daedalus.daedalus(
-            "Australia",
-            "sars-cov-1",
-            time_end = 100.0,
-            npi = npi
-        )
-        @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-    end
-
-    @testset "Very high R0 with strong intervention" begin
-        # R0=5.0 with 90% reduction
-        npi = Daedalus.DaedalusStructs.TimedNpi(5.0, 50.0, 0.1)
-        result = Daedalus.daedalus(
-            "Australia",
-            "sars-cov-1",
-            time_end = 80.0,
-            npi = npi
-        )
-        @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-    end
-
-    @testset "Late-starting intervention" begin
-        # Intervention starts after epidemic peak likely passed
-        npi = Daedalus.DaedalusStructs.TimedNpi(150.0, 180.0, 0.3)
-        result = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 200.0,
-            npi = npi
-        )
-        @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-    end
-end
-
 @testset "Npi with flexible parameter effects" begin
-    @testset "Single parameter (new style with ParamEffect)" begin
-        effect = Daedalus.DaedalusStructs.ParamEffect(
+    @testset "Single parameter (new style with ReactiveEffect)" begin
+        effect = Daedalus.DaedalusStructs.ReactiveEffect(
             :beta, x -> x .* 0.5, x -> x ./ 0.5;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
@@ -551,11 +159,11 @@ end
     end
 
     @testset "Multiple parameters" begin
-        effect_beta = Daedalus.DaedalusStructs.ParamEffect(
+        effect_beta = Daedalus.DaedalusStructs.ReactiveEffect(
             :beta, x -> x .* 0.6, x -> x ./ 0.6;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
-        effect_omega = Daedalus.DaedalusStructs.ParamEffect(
+        effect_omega = Daedalus.DaedalusStructs.ReactiveEffect(
             :omega, x -> x .* 0.6, x -> x ./ 0.6;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
@@ -574,12 +182,11 @@ end
     end
 
     @testset "Different functions for different parameters" begin
-        # New style: each parameter can have its own trigger and function
-        effect_beta = Daedalus.DaedalusStructs.ParamEffect(
+        effect_beta = Daedalus.DaedalusStructs.ReactiveEffect(
             :beta, x -> x .* 0.4, x -> x ./ 0.4;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
-        effect_omega = Daedalus.DaedalusStructs.ParamEffect(
+        effect_omega = Daedalus.DaedalusStructs.ReactiveEffect(
             :omega, x -> x .* 0.7, x -> x ./ 0.7;
             on = ("D", 100.0), off = ("Rt", 1.0)
         )
@@ -598,12 +205,11 @@ end
     end
 
     @testset "Per-parameter independent triggers" begin
-        # New style: each effect has its own trigger compartment
-        effect_beta = Daedalus.DaedalusStructs.ParamEffect(
+        effect_beta = Daedalus.DaedalusStructs.ReactiveEffect(
             :beta, x -> x .* 0.4, x -> x ./ 0.4;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
-        effect_omega = Daedalus.DaedalusStructs.ParamEffect(
+        effect_omega = Daedalus.DaedalusStructs.ReactiveEffect(
             :omega, x -> x .* 0.7, x -> x ./ 0.7;
             on = ("D", 100.0), off = ("Rt", 1.0)
         )
@@ -611,11 +217,9 @@ end
         @test length(npi.effects) == 2
         @test npi.effects[1].target == :beta
         @test npi.effects[2].target == :omega
-        # Verify the functions are different
         test_val = 2.0
-        @test npi.effects[1].func(test_val) ≈ 0.8  # 2.0 * 0.4
-        @test npi.effects[2].func(test_val) ≈ 1.4  # 2.0 * 0.7
-        # Verify the triggers are different
+        @test npi.effects[1].func(test_val) ≈ 0.8
+        @test npi.effects[2].func(test_val) ≈ 1.4
         @test npi.effects[1].comp_on.name == "H"
         @test npi.effects[2].comp_on.name == "D"
 
@@ -629,29 +233,25 @@ end
     end
 
     @testset "Multiple effects with different on/off conditions" begin
-        # Each effect can have completely independent conditions
-        effect_beta = Daedalus.DaedalusStructs.ParamEffect(
+        effect_beta = Daedalus.DaedalusStructs.ReactiveEffect(
             :beta, x -> x .* 0.5, x -> x ./ 0.5;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
-        effect_omega = Daedalus.DaedalusStructs.ParamEffect(
+        effect_omega = Daedalus.DaedalusStructs.ReactiveEffect(
             :omega, x -> x .* 0.9, x -> x ./ 0.9;
             on = ("I", 10000.0), off = ("H", 2000.0)
         )
         npi = Daedalus.DaedalusStructs.Npi([effect_beta, effect_omega])
         @test length(npi.effects) == 2
-        # Verify we have both params
         param_names = Set(eff.target for eff in npi.effects)
         @test param_names == Set([:beta, :omega])
 
-        # Verify the functions produce correct values
         beta_eff = [eff for eff in npi.effects if eff.target == :beta][1]
         omega_eff = [eff for eff in npi.effects if eff.target == :omega][1]
         test_val = 10.0
-        @test beta_eff.func(test_val) ≈ 5.0   # 10.0 * 0.5
-        @test omega_eff.func(test_val) ≈ 9.0  # 10.0 * 0.9
+        @test beta_eff.func(test_val) ≈ 5.0
+        @test omega_eff.func(test_val) ≈ 9.0
 
-        # Verify the on/off conditions are different
         @test beta_eff.comp_on.name == "H"
         @test beta_eff.comp_on.value == 5000.0
         @test omega_eff.comp_on.name == "I"
@@ -670,18 +270,17 @@ end
 end
 
 @testset "Npi with per-effect trigger conditions" begin
-    @testset "Direct ParamEffect construction with custom triggers" begin
-        # Create effects with different trigger compartments
-        effect_beta = Daedalus.DaedalusStructs.ParamEffect(
+    @testset "Direct ReactiveEffect construction with custom triggers" begin
+        effect_beta = Daedalus.DaedalusStructs.ReactiveEffect(
             :beta, x -> x .* 0.4, x -> x ./ 0.4;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
-        effect_gamma = Daedalus.DaedalusStructs.ParamEffect(
+        effect_gamma = Daedalus.DaedalusStructs.ReactiveEffect(
             :omega, x -> x .* 0.8, x -> x ./ 0.8;
             on = ("D", 100.0), off = ("Rt", 1.0)
         )
 
-        npi = Daedalus.DaedalusStructs.Npi([effect_beta, effect_gamma]);
+        npi = Daedalus.DaedalusStructs.Npi([effect_beta, effect_gamma])
         @test length(npi.effects) == 2
         @test npi.effects[1].target == :beta
         @test npi.effects[2].target == :omega
@@ -690,19 +289,17 @@ end
         @test npi.effects[1].comp_on.value == 5000.0
         @test npi.effects[2].comp_on.value == 100.0
 
-        # Verify the NPI can be used in daedalus
         result = Daedalus.daedalus(
             "Australia",
             "influenza 2009",
             time_end = 200.0,
             npi = npi
-        );
+        )
         @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
     end
 
     @testset "Infectious (I) compartment trigger" begin
-        # Test that the new "I" compartment (Ia + Is) can be used as a trigger
-        effect = Daedalus.DaedalusStructs.ParamEffect(
+        effect = Daedalus.DaedalusStructs.ReactiveEffect(
             :beta, x -> x .* 0.5, x -> x ./ 0.5;
             on = ("I", 8000.0), off = ("Rt", 1.0)
         )
@@ -719,18 +316,16 @@ end
     end
 
     @testset "Each effect tracks its own activation state" begin
-        # Effects should have independent ison flags
-        effect1 = Daedalus.DaedalusStructs.ParamEffect(
+        effect1 = Daedalus.DaedalusStructs.ReactiveEffect(
             :beta, x -> x .* 0.4, x -> x ./ 0.4;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
-        effect2 = Daedalus.DaedalusStructs.ParamEffect(
+        effect2 = Daedalus.DaedalusStructs.ReactiveEffect(
             :omega, x -> x .* 0.7, x -> x ./ 0.7;
             on = ("D", 100.0), off = ("Rt", 1.0)
         )
         npi = Daedalus.DaedalusStructs.Npi([effect1, effect2])
 
-        # Before daedalus is run, both should be inactive
         @test !npi.effects[1].ison
         @test !npi.effects[2].ison
     end

--- a/test/test_timed_npi.jl
+++ b/test/test_timed_npi.jl
@@ -3,110 +3,81 @@ using Test
 using OrdinaryDiffEq
 using DiffEqCallbacks
 
-@testset "make_events with timed effects" begin
-    @testset "Callback creation for single timed phase" begin
-        effect = Daedalus.DaedalusStructs.TimedEffect(
-            :beta, x -> x .* 0.5, x -> x ./ 0.5, 10.0, 20.0
+@testset "ParamEffect with reactive triggers" begin
+    @testset "Construct ParamEffect with ReactiveTrigger" begin
+        trigger_on = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.4, x -> x ./ 0.4,
+            trigger_on, trigger_off
         )
-        npi = Daedalus.DaedalusStructs.Npi([effect])
-        savepoints = 0.0:1.0:30.0
-        callbacks = Daedalus.Events.make_events(npi, savepoints)
 
-        @test isa(callbacks, DiffEqCallbacks.CallbackSet)
-        # Should have 2 callbacks: one for activation at start_time, one for deactivation at end_time
-        @test length(callbacks.discrete_callbacks) == 2
+        @test effect.target == :beta
+        @test effect.trigger_on.value == 5000.0
+        @test effect.trigger_on.name == "H"
+        @test effect.trigger_off.value == 1.0
+        @test effect.trigger_off.name == "Rt"
+        @test !effect.ison
     end
 
-    @testset "Callback creation for multiple timed phases" begin
-        effect1 = Daedalus.DaedalusStructs.TimedEffect(
-            :beta, x -> x .* 0.7, x -> x ./ 0.7, 10.0, 20.0
+    @testset "ParamEffect with timed triggers" begin
+        trigger_on = Daedalus.DaedalusStructs.TimeTrigger(10.0, "time")
+        trigger_off = Daedalus.DaedalusStructs.TimeTrigger(20.0, "time")
+        effect = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.5, x -> x ./ 0.5,
+            trigger_on, trigger_off
         )
-        effect2 = Daedalus.DaedalusStructs.TimedEffect(
-            :beta, x -> x .* 0.3, x -> x ./ 0.3, 30.0, 40.0
-        )
-        effect3 = Daedalus.DaedalusStructs.TimedEffect(
-            :beta, x -> x .* 0.5, x -> x ./ 0.5, 60.0, 80.0
-        )
-        npi = Daedalus.DaedalusStructs.Npi([effect1, effect2, effect3])
-        savepoints = 0.0:1.0:100.0
-        callbacks = Daedalus.Events.make_events(npi, savepoints)
 
-        @test isa(callbacks, DiffEqCallbacks.CallbackSet)
-        # Should have 6 callbacks: 2 per effect (on/off)
-        @test length(callbacks.discrete_callbacks) == 6
+        @test effect.target == :beta
+        @test effect.trigger_on.value == 10.0
+        @test effect.trigger_off.value == 20.0
+        @test !effect.ison
     end
 end
 
-@testset "TimedEffect integration with daedalus model" begin
-    @testset "Model runs with single timed effect" begin
-        effect = Daedalus.DaedalusStructs.TimedEffect(
-            :beta, x -> x .* 0.5, x -> x ./ 0.5, 15.0, 45.0
+@testset "Npi with ParamEffect" begin
+    @testset "Npi construction with single reactive effect" begin
+        trigger_on = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.4, x -> x ./ 0.4,
+            trigger_on, trigger_off
         )
         npi = Daedalus.DaedalusStructs.Npi([effect])
 
-        result = Daedalus.daedalus(
-            "Australia",
-            "sars-cov-2 delta",
-            time_end = 80.0,
-            increment = 1.0,
-            npi = npi,
-            log_rt = true
-        )
-
-        @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-        @test result.npi === npi
-        @test result.saves == []  # TimedEffect has no saves, returns []
+        @test length(npi.effects) == 1
+        @test npi.effects[1].target == :beta
     end
 
-    @testset "Model runs with multiple timed effects" begin
-        effect1 = Daedalus.DaedalusStructs.TimedEffect(
-            :beta, x -> x .* 0.7, x -> x ./ 0.7, 10.0, 25.0
-        )
-        effect2 = Daedalus.DaedalusStructs.TimedEffect(
-            :beta, x -> x .* 0.4, x -> x ./ 0.4, 30.0, 50.0
-        )
-        effect3 = Daedalus.DaedalusStructs.TimedEffect(
-            :beta, x -> x .* 0.6, x -> x ./ 0.6, 60.0, 75.0
-        )
-        npi = Daedalus.DaedalusStructs.Npi([effect1, effect2, effect3])
-
-        result = Daedalus.daedalus(
-            "Australia",
-            "sars-cov-1",
-            time_end = 100.0,
-            increment = 1.0,
-            npi = npi,
-            log_rt = false
-        );
-
-        @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-        @test result.npi === npi
-        @test result.saves == []
-    end
-
-    @testset "Model runs without Rt logging" begin
-        effect = Daedalus.DaedalusStructs.TimedEffect(
-            :beta, x -> x .* 0.3, x -> x ./ 0.3, 20.0, 40.0
-        )
-        npi = Daedalus.DaedalusStructs.Npi([effect])
-
-        result = Daedalus.daedalus(
-            "Australia",
-            "sars-cov-1",
-            time_end = 60.0,
-            npi = npi,
-            log_rt = false
+    @testset "Npi construction with multiple effects" begin
+        trigger_on1 = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger_off1 = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect1 = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.4, x -> x ./ 0.4,
+            trigger_on1, trigger_off1
         )
 
-        @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
+        trigger_on2 = Daedalus.DaedalusStructs.ReactiveTrigger(100.0, "D")
+        trigger_off2 = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect2 = Daedalus.DaedalusStructs.ParamEffect(
+            :omega, x -> x .* 0.8, x -> x ./ 0.8,
+            trigger_on2, trigger_off2
+        )
+
+        npi = Daedalus.DaedalusStructs.Npi([effect1, effect2])
+        @test length(npi.effects) == 2
+        @test npi.effects[1].target == :beta
+        @test npi.effects[2].target == :omega
     end
 end
 
-@testset "TimedEffect and reactive Npi coexistence" begin
-    @testset "Model accepts reactive Npi (unchanged behavior)" begin
-        effect = Daedalus.DaedalusStructs.ReactiveEffect(
-            :beta, x -> x .* 0.4, x -> x ./ 0.4;
-            on = ("H", 5000.0), off = ("Rt", 1.0)
+@testset "Reactive NPI model integration" begin
+    @testset "Model runs with reactive NPI" begin
+        trigger_on = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.4, x -> x ./ 0.4,
+            trigger_on, trigger_off
         )
         npi = Daedalus.DaedalusStructs.Npi([effect])
 
@@ -122,7 +93,7 @@ end
         @test !isnothing(result.saves)  # Reactive NPI has saved values
     end
 
-    @testset "Model accepts nothing (unchanged behavior)" begin
+    @testset "Model runs without NPI" begin
         result = Daedalus.daedalus(
             "Australia",
             "influenza 2009",
@@ -136,35 +107,21 @@ end
     end
 end
 
-@testset "Npi with flexible parameter effects" begin
-    @testset "Single parameter (new style with ReactiveEffect)" begin
-        effect = Daedalus.DaedalusStructs.ReactiveEffect(
-            :beta, x -> x .* 0.5, x -> x ./ 0.5;
-            on = ("H", 5000.0), off = ("Rt", 1.0)
-        )
-        npi = Daedalus.DaedalusStructs.Npi([effect])
-        @test length(npi.effects) == 1
-        @test npi.effects[1].target == :beta
+@testset "Npi with multiple reactive effects" begin
+    @testset "Multiple parameters with same triggers" begin
+        trigger_on = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
 
-        result = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 200.0,
-            npi = npi
+        effect_beta = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.6, x -> x ./ 0.6,
+            trigger_on, trigger_off
         )
-        @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-    end
-
-    @testset "Multiple parameters" begin
-        effect_beta = Daedalus.DaedalusStructs.ReactiveEffect(
-            :beta, x -> x .* 0.6, x -> x ./ 0.6;
-            on = ("H", 5000.0), off = ("Rt", 1.0)
-        )
-        effect_omega = Daedalus.DaedalusStructs.ReactiveEffect(
-            :omega, x -> x .* 0.6, x -> x ./ 0.6;
-            on = ("H", 5000.0), off = ("Rt", 1.0)
+        effect_omega = Daedalus.DaedalusStructs.ParamEffect(
+            :omega, x -> x .* 0.6, x -> x ./ 0.6,
+            trigger_on, trigger_off
         )
         npi = Daedalus.DaedalusStructs.Npi([effect_beta, effect_omega])
+
         @test length(npi.effects) == 2
         @test npi.effects[1].target == :beta
         @test npi.effects[2].target == :omega
@@ -172,157 +129,96 @@ end
         result = Daedalus.daedalus(
             "Australia",
             "influenza 2009",
-            time_end = 200.0,
+            time_end = 100.0,
             npi = npi
         )
         @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
     end
 
-    @testset "Different functions for different parameters" begin
-        effect_beta = Daedalus.DaedalusStructs.ReactiveEffect(
-            :beta, x -> x .* 0.4, x -> x ./ 0.4;
-            on = ("H", 5000.0), off = ("Rt", 1.0)
+    @testset "Different transformation functions per parameter" begin
+        trigger_on_beta = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger_off_beta = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect_beta = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.4, x -> x ./ 0.4,
+            trigger_on_beta, trigger_off_beta
         )
-        effect_omega = Daedalus.DaedalusStructs.ReactiveEffect(
-            :omega, x -> x .* 0.7, x -> x ./ 0.7;
-            on = ("D", 100.0), off = ("Rt", 1.0)
+
+        trigger_on_omega = Daedalus.DaedalusStructs.ReactiveTrigger(100.0, "D")
+        trigger_off_omega = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect_omega = Daedalus.DaedalusStructs.ParamEffect(
+            :omega, x -> x .* 0.7, x -> x ./ 0.7,
+            trigger_on_omega, trigger_off_omega
         )
+
         npi = Daedalus.DaedalusStructs.Npi([effect_beta, effect_omega])
         @test length(npi.effects) == 2
-        @test npi.effects[1].target == :beta
-        @test npi.effects[2].target == :omega
 
-        result = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 200.0,
-            npi = npi
-        )
-        @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-    end
-
-    @testset "Per-parameter independent triggers" begin
-        effect_beta = Daedalus.DaedalusStructs.ReactiveEffect(
-            :beta, x -> x .* 0.4, x -> x ./ 0.4;
-            on = ("H", 5000.0), off = ("Rt", 1.0)
-        )
-        effect_omega = Daedalus.DaedalusStructs.ReactiveEffect(
-            :omega, x -> x .* 0.7, x -> x ./ 0.7;
-            on = ("D", 100.0), off = ("Rt", 1.0)
-        )
-        npi = Daedalus.DaedalusStructs.Npi([effect_beta, effect_omega])
-        @test length(npi.effects) == 2
-        @test npi.effects[1].target == :beta
-        @test npi.effects[2].target == :omega
         test_val = 2.0
         @test npi.effects[1].func(test_val) ≈ 0.8
         @test npi.effects[2].func(test_val) ≈ 1.4
-        @test npi.effects[1].comp_on.name == "H"
-        @test npi.effects[2].comp_on.name == "D"
 
         result = Daedalus.daedalus(
             "Australia",
             "influenza 2009",
-            time_end = 200.0,
+            time_end = 100.0,
             npi = npi
         )
         @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
     end
 
-    @testset "Multiple effects with different on/off conditions" begin
-        effect_beta = Daedalus.DaedalusStructs.ReactiveEffect(
-            :beta, x -> x .* 0.5, x -> x ./ 0.5;
-            on = ("H", 5000.0), off = ("Rt", 1.0)
+    @testset "Independent triggers for each effect" begin
+        trigger_on_beta = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger_off_beta = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect_beta = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.5, x -> x ./ 0.5,
+            trigger_on_beta, trigger_off_beta
         )
-        effect_omega = Daedalus.DaedalusStructs.ReactiveEffect(
-            :omega, x -> x .* 0.9, x -> x ./ 0.9;
-            on = ("I", 10000.0), off = ("H", 2000.0)
+
+        trigger_on_omega = Daedalus.DaedalusStructs.ReactiveTrigger(10000.0, "I")
+        trigger_off_omega = Daedalus.DaedalusStructs.ReactiveTrigger(2000.0, "H")
+        effect_omega = Daedalus.DaedalusStructs.ParamEffect(
+            :omega, x -> x .* 0.9, x -> x ./ 0.9,
+            trigger_on_omega, trigger_off_omega
         )
+
         npi = Daedalus.DaedalusStructs.Npi([effect_beta, effect_omega])
         @test length(npi.effects) == 2
-        param_names = Set(eff.target for eff in npi.effects)
-        @test param_names == Set([:beta, :omega])
 
-        beta_eff = [eff for eff in npi.effects if eff.target == :beta][1]
-        omega_eff = [eff for eff in npi.effects if eff.target == :omega][1]
-        test_val = 10.0
-        @test beta_eff.func(test_val) ≈ 5.0
-        @test omega_eff.func(test_val) ≈ 9.0
+        beta_eff = npi.effects[1]
+        omega_eff = npi.effects[2]
 
-        @test beta_eff.comp_on.name == "H"
-        @test beta_eff.comp_on.value == 5000.0
-        @test omega_eff.comp_on.name == "I"
-        @test omega_eff.comp_on.value == 10000.0
-        @test beta_eff.comp_off.name == "Rt"
-        @test omega_eff.comp_off.name == "H"
+        @test beta_eff.trigger_on.name == "H"
+        @test beta_eff.trigger_on.value == 5000.0
+        @test beta_eff.trigger_off.name == "Rt"
+        @test omega_eff.trigger_on.name == "I"
+        @test omega_eff.trigger_on.value == 10000.0
+        @test omega_eff.trigger_off.name == "H"
 
         result = Daedalus.daedalus(
             "Australia",
             "influenza 2009",
-            time_end = 200.0,
-            npi = npi
-        )
-        @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-    end
-end
-
-@testset "Npi with per-effect trigger conditions" begin
-    @testset "Direct ReactiveEffect construction with custom triggers" begin
-        effect_beta = Daedalus.DaedalusStructs.ReactiveEffect(
-            :beta, x -> x .* 0.4, x -> x ./ 0.4;
-            on = ("H", 5000.0), off = ("Rt", 1.0)
-        )
-        effect_gamma = Daedalus.DaedalusStructs.ReactiveEffect(
-            :omega, x -> x .* 0.8, x -> x ./ 0.8;
-            on = ("D", 100.0), off = ("Rt", 1.0)
-        )
-
-        npi = Daedalus.DaedalusStructs.Npi([effect_beta, effect_gamma])
-        @test length(npi.effects) == 2
-        @test npi.effects[1].target == :beta
-        @test npi.effects[2].target == :omega
-        @test npi.effects[1].comp_on.name == "H"
-        @test npi.effects[2].comp_on.name == "D"
-        @test npi.effects[1].comp_on.value == 5000.0
-        @test npi.effects[2].comp_on.value == 100.0
-
-        result = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 200.0,
-            npi = npi
-        )
-        @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
-    end
-
-    @testset "Infectious (I) compartment trigger" begin
-        effect = Daedalus.DaedalusStructs.ReactiveEffect(
-            :beta, x -> x .* 0.5, x -> x ./ 0.5;
-            on = ("I", 8000.0), off = ("Rt", 1.0)
-        )
-        npi = Daedalus.DaedalusStructs.Npi([effect])
-        @test npi.effects[1].comp_on.name == "I"
-
-        result = Daedalus.daedalus(
-            "Australia",
-            "influenza 2009",
-            time_end = 200.0,
+            time_end = 100.0,
             npi = npi
         )
         @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
     end
 
     @testset "Each effect tracks its own activation state" begin
-        effect1 = Daedalus.DaedalusStructs.ReactiveEffect(
-            :beta, x -> x .* 0.4, x -> x ./ 0.4;
-            on = ("H", 5000.0), off = ("Rt", 1.0)
+        trigger_on1 = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger_off1 = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect1 = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.4, x -> x ./ 0.4,
+            trigger_on1, trigger_off1
         )
-        effect2 = Daedalus.DaedalusStructs.ReactiveEffect(
-            :omega, x -> x .* 0.7, x -> x ./ 0.7;
-            on = ("D", 100.0), off = ("Rt", 1.0)
-        )
-        npi = Daedalus.DaedalusStructs.Npi([effect1, effect2])
 
+        trigger_on2 = Daedalus.DaedalusStructs.ReactiveTrigger(100.0, "D")
+        trigger_off2 = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect2 = Daedalus.DaedalusStructs.ParamEffect(
+            :omega, x -> x .* 0.7, x -> x ./ 0.7,
+            trigger_on2, trigger_off2
+        )
+
+        npi = Daedalus.DaedalusStructs.Npi([effect1, effect2])
         @test !npi.effects[1].ison
         @test !npi.effects[2].ison
     end

--- a/test/test_timed_npi.jl
+++ b/test/test_timed_npi.jl
@@ -413,7 +413,7 @@ end
 @testset "TimedNpi vs reactive Npi coexistence" begin
     @testset "Model accepts reactive Npi (unchanged behavior)" begin
         effect = Daedalus.DaedalusStructs.ParamEffect(
-            :beta, original -> original .* 0.4;
+            :beta, x -> x .* 0.4, x -> x ./ 0.4;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
         npi = Daedalus.DaedalusStructs.Npi([effect])
@@ -534,12 +534,12 @@ end
 @testset "Npi with flexible parameter effects" begin
     @testset "Single parameter (new style with ParamEffect)" begin
         effect = Daedalus.DaedalusStructs.ParamEffect(
-            :beta, x -> x .* 0.5;
+            :beta, x -> x .* 0.5, x -> x ./ 0.5;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
         npi = Daedalus.DaedalusStructs.Npi([effect])
         @test length(npi.effects) == 1
-        @test npi.effects[1].name == :beta
+        @test npi.effects[1].target == :beta
 
         result = Daedalus.daedalus(
             "Australia",
@@ -552,17 +552,17 @@ end
 
     @testset "Multiple parameters" begin
         effect_beta = Daedalus.DaedalusStructs.ParamEffect(
-            :beta, x -> x .* 0.6;
+            :beta, x -> x .* 0.6, x -> x ./ 0.6;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
         effect_omega = Daedalus.DaedalusStructs.ParamEffect(
-            :omega, x -> x .* 0.6;
+            :omega, x -> x .* 0.6, x -> x ./ 0.6;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
         npi = Daedalus.DaedalusStructs.Npi([effect_beta, effect_omega])
         @test length(npi.effects) == 2
-        @test npi.effects[1].name == :beta
-        @test npi.effects[2].name == :omega
+        @test npi.effects[1].target == :beta
+        @test npi.effects[2].target == :omega
 
         result = Daedalus.daedalus(
             "Australia",
@@ -576,17 +576,17 @@ end
     @testset "Different functions for different parameters" begin
         # New style: each parameter can have its own trigger and function
         effect_beta = Daedalus.DaedalusStructs.ParamEffect(
-            :beta, x -> x .* 0.4;
+            :beta, x -> x .* 0.4, x -> x ./ 0.4;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
         effect_omega = Daedalus.DaedalusStructs.ParamEffect(
-            :omega, x -> x .* 0.7;
+            :omega, x -> x .* 0.7, x -> x ./ 0.7;
             on = ("D", 100.0), off = ("Rt", 1.0)
         )
         npi = Daedalus.DaedalusStructs.Npi([effect_beta, effect_omega])
         @test length(npi.effects) == 2
-        @test npi.effects[1].name == :beta
-        @test npi.effects[2].name == :omega
+        @test npi.effects[1].target == :beta
+        @test npi.effects[2].target == :omega
 
         result = Daedalus.daedalus(
             "Australia",
@@ -600,17 +600,17 @@ end
     @testset "Per-parameter independent triggers" begin
         # New style: each effect has its own trigger compartment
         effect_beta = Daedalus.DaedalusStructs.ParamEffect(
-            :beta, x -> x .* 0.4;
+            :beta, x -> x .* 0.4, x -> x ./ 0.4;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
         effect_omega = Daedalus.DaedalusStructs.ParamEffect(
-            :omega, x -> x .* 0.7;
+            :omega, x -> x .* 0.7, x -> x ./ 0.7;
             on = ("D", 100.0), off = ("Rt", 1.0)
         )
         npi = Daedalus.DaedalusStructs.Npi([effect_beta, effect_omega])
         @test length(npi.effects) == 2
-        @test npi.effects[1].name == :beta
-        @test npi.effects[2].name == :omega
+        @test npi.effects[1].target == :beta
+        @test npi.effects[2].target == :omega
         # Verify the functions are different
         test_val = 2.0
         @test npi.effects[1].func(test_val) ≈ 0.8  # 2.0 * 0.4
@@ -631,22 +631,22 @@ end
     @testset "Multiple effects with different on/off conditions" begin
         # Each effect can have completely independent conditions
         effect_beta = Daedalus.DaedalusStructs.ParamEffect(
-            :beta, x -> x .* 0.5;
+            :beta, x -> x .* 0.5, x -> x ./ 0.5;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
         effect_omega = Daedalus.DaedalusStructs.ParamEffect(
-            :omega, x -> x .* 0.9;
+            :omega, x -> x .* 0.9, x -> x ./ 0.9;
             on = ("I", 10000.0), off = ("H", 2000.0)
         )
         npi = Daedalus.DaedalusStructs.Npi([effect_beta, effect_omega])
         @test length(npi.effects) == 2
         # Verify we have both params
-        param_names = Set(eff.name for eff in npi.effects)
+        param_names = Set(eff.target for eff in npi.effects)
         @test param_names == Set([:beta, :omega])
 
         # Verify the functions produce correct values
-        beta_eff = [eff for eff in npi.effects if eff.name == :beta][1]
-        omega_eff = [eff for eff in npi.effects if eff.name == :omega][1]
+        beta_eff = [eff for eff in npi.effects if eff.target == :beta][1]
+        omega_eff = [eff for eff in npi.effects if eff.target == :omega][1]
         test_val = 10.0
         @test beta_eff.func(test_val) ≈ 5.0   # 10.0 * 0.5
         @test omega_eff.func(test_val) ≈ 9.0  # 10.0 * 0.9
@@ -673,18 +673,18 @@ end
     @testset "Direct ParamEffect construction with custom triggers" begin
         # Create effects with different trigger compartments
         effect_beta = Daedalus.DaedalusStructs.ParamEffect(
-            :beta, x -> x .* 0.4;
+            :beta, x -> x .* 0.4, x -> x ./ 0.4;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
         effect_gamma = Daedalus.DaedalusStructs.ParamEffect(
-            :omega, x -> x .* 0.8;
+            :omega, x -> x .* 0.8, x -> x ./ 0.8;
             on = ("D", 100.0), off = ("Rt", 1.0)
         )
 
         npi = Daedalus.DaedalusStructs.Npi([effect_beta, effect_gamma]);
         @test length(npi.effects) == 2
-        @test npi.effects[1].name == :beta
-        @test npi.effects[2].name == :omega
+        @test npi.effects[1].target == :beta
+        @test npi.effects[2].target == :omega
         @test npi.effects[1].comp_on.name == "H"
         @test npi.effects[2].comp_on.name == "D"
         @test npi.effects[1].comp_on.value == 5000.0
@@ -703,7 +703,7 @@ end
     @testset "Infectious (I) compartment trigger" begin
         # Test that the new "I" compartment (Ia + Is) can be used as a trigger
         effect = Daedalus.DaedalusStructs.ParamEffect(
-            :beta, x -> x .* 0.5;
+            :beta, x -> x .* 0.5, x -> x ./ 0.5;
             on = ("I", 8000.0), off = ("Rt", 1.0)
         )
         npi = Daedalus.DaedalusStructs.Npi([effect])
@@ -721,11 +721,11 @@ end
     @testset "Each effect tracks its own activation state" begin
         # Effects should have independent ison flags
         effect1 = Daedalus.DaedalusStructs.ParamEffect(
-            :beta, x -> x .* 0.4;
+            :beta, x -> x .* 0.4, x -> x ./ 0.4;
             on = ("H", 5000.0), off = ("Rt", 1.0)
         )
         effect2 = Daedalus.DaedalusStructs.ParamEffect(
-            :omega, x -> x .* 0.7;
+            :omega, x -> x .* 0.7, x -> x ./ 0.7;
             on = ("D", 100.0), off = ("Rt", 1.0)
         )
         npi = Daedalus.DaedalusStructs.Npi([effect1, effect2])

--- a/test/test_timed_npi.jl
+++ b/test/test_timed_npi.jl
@@ -44,12 +44,9 @@ end
         )
         npi = Daedalus.DaedalusStructs.Npi([effect])
 
-        infection = Daedalus.DataLoader.get_pathogen("sars-cov-2 delta")
-        infection.r0 = 2.0
-
         result = Daedalus.daedalus(
             "Australia",
-            infection,
+            "sars-cov-2 delta",
             time_end = 80.0,
             increment = 1.0,
             npi = npi,
@@ -58,7 +55,7 @@ end
 
         @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
         @test result.npi === npi
-        @test isnothing(result.saves)  # TimedEffect has no saved values
+        @test result.saves == []  # TimedEffect has no saves, returns []
     end
 
     @testset "Model runs with multiple timed effects" begin
@@ -80,11 +77,11 @@ end
             increment = 1.0,
             npi = npi,
             log_rt = false
-        )
+        );
 
         @test result.sol.retcode == OrdinaryDiffEq.ReturnCode.Success
         @test result.npi === npi
-        @test isnothing(result.saves)
+        @test result.saves == []
     end
 
     @testset "Model runs without Rt logging" begin

--- a/test/test_triggers_effects.jl
+++ b/test/test_triggers_effects.jl
@@ -1,0 +1,145 @@
+using Daedalus
+using Test
+
+@testset "Trigger types" begin
+    @testset "ReactiveTrigger construction and fields" begin
+        trigger = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        @test trigger.value == 5000.0
+        @test trigger.name == "H"
+    end
+
+    @testset "TimeTrigger construction and fields" begin
+        trigger = Daedalus.DaedalusStructs.TimeTrigger(10.0, "time")
+        @test trigger.value == 10.0
+        @test trigger.name == "time"
+    end
+
+    @testset "TimeTrigger with default name" begin
+        trigger = Daedalus.DaedalusStructs.TimeTrigger(15.0)
+        @test trigger.value == 15.0
+        @test trigger.name == "time"
+    end
+
+    @testset "Trigger is abstract type" begin
+        trigger_reactive = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger_time = Daedalus.DaedalusStructs.TimeTrigger(10.0)
+
+        @test trigger_reactive isa Daedalus.DaedalusStructs.Trigger
+        @test trigger_time isa Daedalus.DaedalusStructs.Trigger
+    end
+end
+
+@testset "ParamEffect basic functionality" begin
+    @testset "ParamEffect with ReactiveTriggers" begin
+        trigger_on = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+
+        effect = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.5, x -> x ./ 0.5,
+            trigger_on, trigger_off
+        )
+
+        @test effect.target == :beta
+        @test effect.trigger_on.value == 5000.0
+        @test effect.trigger_off.value == 1.0
+        @test !effect.ison  # Initially inactive
+    end
+
+    @testset "ParamEffect with TimeTriggers" begin
+        trigger_on = Daedalus.DaedalusStructs.TimeTrigger(10.0)
+        trigger_off = Daedalus.DaedalusStructs.TimeTrigger(20.0)
+
+        effect = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.7, x -> x ./ 0.7,
+            trigger_on, trigger_off
+        )
+
+        @test effect.target == :beta
+        @test isa(effect.trigger_on, Daedalus.DaedalusStructs.TimeTrigger)
+        @test isa(effect.trigger_off, Daedalus.DaedalusStructs.TimeTrigger)
+    end
+
+    @testset "ParamEffect is an Effect" begin
+        trigger_on = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+
+        effect = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.5, x -> x ./ 0.5,
+            trigger_on, trigger_off
+        )
+
+        @test effect isa Daedalus.DaedalusStructs.Effect
+    end
+
+    @testset "ParamEffect function application" begin
+        trigger_on = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+
+        effect = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.4, x -> x ./ 0.4,
+            trigger_on, trigger_off
+        )
+
+        test_val = 10.0
+        @test effect.func(test_val) ≈ 4.0
+        @test effect.reset_func(4.0) ≈ 10.0
+    end
+end
+
+@testset "Npi container" begin
+    @testset "Npi with single effect" begin
+        trigger_on = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.5, x -> x ./ 0.5,
+            trigger_on, trigger_off
+        )
+
+        npi = Daedalus.DaedalusStructs.Npi([effect])
+        @test length(npi.effects) == 1
+        @test npi.effects[1] === effect
+    end
+
+    @testset "Npi with multiple effects" begin
+        trigger1_on = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger1_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect1 = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.5, x -> x ./ 0.5,
+            trigger1_on, trigger1_off
+        )
+
+        trigger2_on = Daedalus.DaedalusStructs.ReactiveTrigger(100.0, "D")
+        trigger2_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect2 = Daedalus.DaedalusStructs.ParamEffect(
+            :omega, x -> x .* 0.8, x -> x ./ 0.8,
+            trigger2_on, trigger2_off
+        )
+
+        npi = Daedalus.DaedalusStructs.Npi([effect1, effect2])
+        @test length(npi.effects) == 2
+        @test npi.effects[1].target == :beta
+        @test npi.effects[2].target == :omega
+    end
+
+    @testset "Npi is an Event" begin
+        trigger_on = Daedalus.DaedalusStructs.ReactiveTrigger(5000.0, "H")
+        trigger_off = Daedalus.DaedalusStructs.ReactiveTrigger(1.0, "Rt")
+        effect = Daedalus.DaedalusStructs.ParamEffect(
+            :beta, x -> x .* 0.5, x -> x ./ 0.5,
+            trigger_on, trigger_off
+        )
+
+        npi = Daedalus.DaedalusStructs.Npi([effect])
+        @test npi isa Daedalus.DaedalusStructs.Event
+    end
+end
+
+@testset "Exported types verification" begin
+    # Verify that the correct types are exported
+    @test Daedalus.DaedalusStructs.ParamEffect isa DataType
+    @test Daedalus.DaedalusStructs.Effect isa DataType
+    @test Daedalus.DaedalusStructs.Trigger isa DataType
+    @test Daedalus.DaedalusStructs.ReactiveTrigger isa DataType
+    @test Daedalus.DaedalusStructs.TimeTrigger isa DataType
+    @test Daedalus.DaedalusStructs.Npi isa DataType
+end


### PR DESCRIPTION
This PR aims to unify reactive and timed NPI effects, with a lot more modularity. There is still some functionality that's used to account for ending on $R_t$, but otherwise the general concept of a function and `Callback` factory for epi modelling is now being developed in a prototype package [EpiEvents.jl](https://github.com/jameel-institute/EpiEvents.jl).

The overall implementation is pretty similar to what I have in R/C++ daedalus. What's missing:
1. Duration-based NPIs,
2. System-level tracking of which NPIs or effects are active when.

Conceptually, the issue with allowing an unlimited number of NPIs with multiple effects is that the book-keeping becomes more challenging, and that's a problem when a key part of the modelling output is some function of NPI durations and effects.